### PR TITLE
plan: vendor go-runewidth as a patched fork, bump tinygo to 0.41.1

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -264,5 +264,5 @@ footer: |
 | 2608021916 | 🔲     | sonnet | [Split internal/githooks by responsibility](plan/2608021916_arch-fix-githooks-package-split.md)                                                         |
 | 2608091910 | ✅     | sonnet | [Resolve the MDS073 rule-ID collision between slidevstructure and foreignregion](plan/2608091910_arch-fix-mds073-collision.md)                          |
 | 2608091911 | 🔲     | haiku  | [Add dedicated unit tests for occurrence and slidevstructure private helpers](plan/2608091911_arch-fix-missing-unit-tests.md)                           |
-| 2608161754 | 🔲     | sonnet | [Vendor go-runewidth as a patched fork and bump tinygo to 0.41.1](plan/2608161754_vendor-runewidth-bump-tinygo.md)                                      |
+| 2608161754 | 🔲     | sonnet | [Vendor go-runewidth as a patched fork so post-LUT versions build under tinygo](plan/2608161754_vendor-runewidth-bump-tinygo.md)                        |
 <?/catalog?>

--- a/PLAN.md
+++ b/PLAN.md
@@ -264,4 +264,5 @@ footer: |
 | 2608021916 | 🔲     | sonnet | [Split internal/githooks by responsibility](plan/2608021916_arch-fix-githooks-package-split.md)                                                         |
 | 2608091910 | ✅     | sonnet | [Resolve the MDS073 rule-ID collision between slidevstructure and foreignregion](plan/2608091910_arch-fix-mds073-collision.md)                          |
 | 2608091911 | 🔲     | haiku  | [Add dedicated unit tests for occurrence and slidevstructure private helpers](plan/2608091911_arch-fix-missing-unit-tests.md)                           |
+| 2608161754 | 🔲     | sonnet | [Vendor go-runewidth as a patched fork and bump tinygo to 0.41.1](plan/2608161754_vendor-runewidth-bump-tinygo.md)                                      |
 <?/catalog?>

--- a/plan/2608161754_vendor-runewidth-bump-tinygo.md
+++ b/plan/2608161754_vendor-runewidth-bump-tinygo.md
@@ -130,11 +130,20 @@ every file with no tables at all. The benefit is roughly
 100 ns saved per CJK table cell. Around 127,000 such cells
 per run are needed just to offset one startup fill.
 
-ASCII content — nearly all Markdown tables — is slightly
-faster without the LUT, because the 2.1 MiB array is a cache
-liability the `r < 0x300` fast path skips. Only wide CJK
-tables are slower, and only in the width step that uax29
-grapheme clustering already dominates.
+**Optimize for English content — the deciding factor.**
+`StringWidth` has an all-ASCII fast path in both 0.0.24 and
+0.0.27: a pure-ASCII string counts printable bytes and never
+calls `RuneWidth`. So English text never reads the LUT at
+all. The LUT gives English content zero per-call benefit,
+while every run still pays its 12.7 ms startup fill. Removed,
+English `StringWidth` is measurably faster and consistently
+so (about 6.5 ns against 8.0 ns per cell across five runs).
+
+mdsmith's own corpus and most Markdown tables are English or
+otherwise ASCII, so this is the case to optimize. The only
+content the LUT helps is wide CJK tables, and only in the
+per-rune width step that uax29 grapheme clustering already
+dominates. That regression is accepted.
 
 Against the current pinned 0.0.24, the width path is
 unchanged: 0.0.24 has no LUT either. A parity test confirms

--- a/plan/2608161754_vendor-runewidth-bump-tinygo.md
+++ b/plan/2608161754_vendor-runewidth-bump-tinygo.md
@@ -1,27 +1,30 @@
 ---
 id: 2608161754
 title: >-
-  Vendor go-runewidth as a patched fork and bump tinygo
-  to 0.41.1
+  Vendor go-runewidth as a patched fork so post-LUT
+  versions build under tinygo
 status: "🔲"
 model: sonnet
 summary: >-
-  go-runewidth 0.0.27 builds a 2.1 MiB strictWidthLUT in
-  package init; tinygo's interp pass tries to constant-fold
-  it and times out, so the wasm build fails and the
-  dependency is stuck at 0.0.24. Vendor the library into
-  pkg/runewidth with its MIT LICENSE, drop the eager LUT,
-  and gate the fork with an upstream A/B parity test wired
-  into CI. Also bump the pinned tinygo to 0.41.1.
+  go-runewidth 0.0.25+ fills a 2.1 MiB strictWidthLUT in
+  package init; tinygo's interp pass constant-folds it and
+  times out, freezing mdsmith at 0.0.24. The LUT is a pure
+  memoization of the runeWidthNoLUT function it keeps, so a
+  vendored fork can delete it with an equivalence-by-
+  construction regression test. Vendor 0.0.27 into
+  pkg/runewidth with its MIT LICENSE, delete the LUT,
+  promote the uax29 grapheme dependency to direct, and drop
+  the module. Retires PR #777.
 depends-on: []
 ---
-# Vendor go-runewidth as a patched fork and bump tinygo to 0.41.1
+# Vendor go-runewidth as a patched fork so post-LUT versions build under tinygo
 
 ## Goal
 
-Own a patched copy of go-runewidth. The wasm build then
-stops failing on an upstream change mdsmith cannot
-otherwise influence.
+Own a patched copy of go-runewidth with the eager width
+lookup table removed. mdsmith can then adopt current and
+future upstream versions, instead of staying pinned at
+0.0.24.
 
 ## Background
 
@@ -33,112 +36,160 @@ runewidth.go:118:6: interp: running for more than 3m0s,
 timing out (executed calls: 189515)
 ```
 
-The traceback names the cause: `init#1` calls
-`initStrictWidthLUT`. Upstream 0.0.27 added a precomputed
-width lookup table, declared as
-`strictWidthLUT [2][0x110000]byte` and filled in package
-`init`. That is 2,228,224 entries, each derived by calling
-`runeWidthNoLUT`. Tinygo's `interp` pass tries to evaluate
-the whole initializer at compile time and gives up at its
-3-minute budget.
+Upstream 0.0.25 added a precomputed width lookup table. It
+is declared `strictWidthLUT [2][0x110000]byte` and filled
+in package `init` — 2,228,224 entries. Tinygo's `interp`
+pass tries to evaluate the whole initializer at compile
+time. It gives up at its 3-minute budget.
 
-Bumping tinygo alone does not fix it. Measured on CI:
-0.39.0 reached 102,156 interpreted calls in 3 minutes and
-0.41.1 reached 189,515 — roughly 1.85 times faster, against
-a workload of millions of calls. Raising
-`-interp-timeout` would charge every future CI run ten
-minutes or more for a dependency bump that carries no
-security fix.
+**Why not just stay on 0.0.24.** That is the zero-work
+option, and 0.0.24 has no LUT (verified: no `strictWidthLUT`
+in its source), so CI is green on it today. But every
+go-runewidth release from 0.0.25 onward carries the LUT
+permanently, so without a fork mdsmith is frozen at 0.0.24
+for good — including for the grapheme-cluster and
+spacing-mark width corrections 0.0.27 brings. Vendoring is
+the forward path; pinning is the dead end.
 
-Two further facts make vendoring the right shape:
+**The fix is mechanical.** The LUT is not new behavior — it
+is a pure cache of a function the fork keeps:
 
-- The LUT is a 2.1 MiB static array. The wasm artifact
-  budget in [size_test.go][sizetest] is 8 MiB raw, so the
-  table alone would consume about a quarter of it even if
-  the compile-time problem were solved.
-- mdsmith uses exactly one symbol from the library,
-  `runewidth.StringWidth`, from three call sites:
-  [tablefmt.go][tablefmt], [parity.go][parity], and
-  [rule_test.go][tabletest].
+```go
+func initStrictWidthLUT() {
+    for i := range strictWidthLUT[0] {
+        strictWidthLUT[0][i] = byte(runeWidthNoLUT(rune(i), false, true))
+        strictWidthLUT[1][i] = byte(runeWidthNoLUT(rune(i), true, true))
+    }
+}
+func (c *Condition) RuneWidth(r rune) int {
+    // ... return int(strictWidthLUT[k][r])
+    // ... fallback: return runeWidthNoLUT(r, c.EastAsianWidth, c.StrictEmojiNeutral)
+}
+```
 
-A precedent already exists. [pkg/goldmark][goldmark] is a
-vendored fork carrying its upstream LICENSE, with a
-`goldmark_upstream` build tag that CI exercises through the
-`goldmark-fork-test` job. This plan follows that shape.
+Deleting the array and routing every read back through
+`runeWidthNoLUT` is equivalent by construction. This is a
+memoization removal, not a behavior fork. So it needs a
+regression test, not the upstream-A/B build-tag apparatus
+[pkg/goldmark][goldmark] uses. Goldmark keeps two real
+runtime paths, arena on and off, that must stay in
+agreement. There is no alternate path to keep here. The LUT
+path simply ceases to exist.
 
-It also avoids a known trap. The archived audit records
-that [internal/mdtext/upstreampunct.go][punct] carries a
-`mdtext_punkt_upstream` tag no workflow ever passes, and
-calls it a "silent bit-rot risk". The parity tag added here
-must run in CI from the first commit.
+**This is still a behavior change, but a different one.**
+Moving from 0.0.24 to 0.0.27 changes some per-rune and
+grapheme-cluster widths — that is what upstream's fixes do.
+Table alignment for emoji/CJK content may shift. That is a
+deliberate upgrade, not a regression, and it is separate
+from the LUT removal, which is width-preserving.
 
-Vendoring also retires [PR #777][pr777] and every future
-dependabot PR for this module, because the `go.mod`
-requirement goes away.
+**A second dependency comes along.**
+`runewidth.StringWidth` routes multi-rune input through
+`github.com/clipperhouse/uax29/v2/graphemes`. This is
+verified in both 0.0.24 and 0.0.27. uax29 is `// indirect`
+in [go.mod][gomod] today. Once go-runewidth is removed, it
+becomes a direct dependency.
+
+Its grapheme trie is generated lookup code, with no `init`
+and no large static array. That makes it a low tinygo risk,
+though the risk must still be confirmed by a real tinygo
+build. uax29 keeps its own dependabot line, which this work
+does not retire.
+
+mdsmith uses exactly one symbol, `runewidth.StringWidth`.
+It has three call sites: [tablefmt.go][tablefmt],
+[parity.go][parity], and [rule_test.go][tabletest]. So the
+fork surface and the repoint are both small.
+
+The archived audit flags a trap to avoid.
+[internal/mdtext/upstreampunct.go][punct]'s
+`mdtext_punkt_upstream` tag is one no workflow runs — a
+"silent bit-rot risk." This plan sidesteps it by design.
+The LUT regression test is an ordinary untagged test in the
+default suite. It always runs, so it cannot rot.
 
 ## Tasks
 
-1. Bump the pinned tinygo in [ci.yml][ci] from 0.39.0 to
-   0.41.1. Set `TINYGO_SHA256` to
-   `901fbccffc61adb111656d1f907dfc21b6c499ca841b115866a0d6de2d835fbe`,
-   computed from the 179,764,108-byte release artifact.
-   Comment why the pin is coupled to go-runewidth.
-2. Copy go-runewidth 0.0.27 into `pkg/runewidth/`: the
-   non-test `.go` files plus `LICENSE`. Record the upstream
-   version and commit in a package doc comment. Do not copy
-   `go.mod`, `go.sum`, or the benchmark scratch files.
-3. Rewrite the package clause and any internal imports for
-   the new path. Keep the exported API byte-identical so a
-   future re-sync stays a mechanical diff.
-4. Write the failing parity test first, behind a
-   `runewidth_upstream` build tag: for every rune in
-   `0..0x10FFFF`, assert the vendored `StringWidth` agrees
-   with upstream 0.0.27. It fails until step 5 lands.
-5. Remove the eager LUT from the fork: delete
-   `strictWidthLUT`, delete `initStrictWidthLUT`, drop its
-   call from `init`, and route the strict-width path
-   through `runeWidthNoLUT`. Do not substitute a
-   `sync.Once`: that keeps the 2.1 MiB array and only moves
-   the cost to the first call.
-6. Add a `runewidth-fork-test` job to [ci.yml][ci] running
-   `go test -tags runewidth_upstream ./pkg/runewidth/...`,
-   mirroring `goldmark-fork-test`. This is the step that
-   keeps the fork honest.
-7. Repoint the three call sites to the vendored package and
-   drop `github.com/mattn/go-runewidth` from `go.mod` and
-   `go.sum`.
-8. Record the fork and its divergence in
-   [markdown-library.md][mdlib] or a sibling development
-   page, so the next person to re-sync knows the LUT
-   removal is deliberate.
-9. Close [PR #777][pr777] as retired by this work.
+1. Spike first: vendor go-runewidth 0.0.27 into
+   `pkg/runewidth/` (non-test `.go` files plus `LICENSE`),
+   rewrite the package path, promote uax29 to a direct
+   `require`, and confirm `tinygo build -target wasm
+   ./cmd/mdsmith-wasm` still times out — establishing the
+   reproduction inside the tree before changing anything.
+   If tinygo instead fails on uax29, stop and re-plan.
+2. Record the upstream version and commit in a package doc
+   comment. Do not copy `go.mod`, `go.sum`, or the
+   benchmark scratch files. Keep the exported API
+   byte-identical so a future re-sync stays a mechanical
+   diff.
+3. Write the regression test first (ordinary test, no build
+   tag): for every rune in `0..0x10FFFF` and both
+   `eastAsian` settings, assert `RuneWidth` equals
+   `runeWidthNoLUT` with the same arguments; add a handful
+   of `StringWidth` cases exercising the uax29 grapheme
+   path (a ZWJ emoji sequence, a regional-indicator flag, a
+   base+combining sequence). It passes on the as-copied
+   fork and must still pass after step 4 — it guards the
+   removal, it does not drive it.
+4. Delete the eager LUT: remove `strictWidthLUT`, remove
+   `initStrictWidthLUT`, drop its call from `init`, and
+   replace every `strictWidthLUT[k][r]` read with the
+   equivalent `runeWidthNoLUT(r, eastAsian, strictEmojiNeutral)`
+   call, preserving the exact arguments each read encoded.
+   Do not substitute a `sync.Once`: that keeps the 2.1 MiB
+   array and only moves the fill to first call.
+5. Repoint the three call sites to `pkg/runewidth` and drop
+   `github.com/mattn/go-runewidth` from [go.mod][gomod] and
+   `go.sum`. Confirm uax29 is now a direct requirement.
+6. Regenerate the table-formatting golden fixtures if the
+   0.0.24 -> 0.0.27 width changes move any output, and
+   review the diff so the shift is understood and intended,
+   not silently absorbed.
+7. Document the fork and its single divergence (the LUT
+   removal) in [markdown-library.md][mdlib] or a sibling
+   development page, so a re-sync knows the deletion is
+   deliberate.
+8. Close [PR #777][pr777] as retired by this work.
+
+## Optional follow-up (not required by this plan)
+
+Bump the pinned tinygo in [ci.yml][ci] from 0.39.0 to
+0.41.1. It is independently worthwhile — newer toolchain,
+LLVM 20, and roughly 1.85x faster interp (measured on CI:
+0.39.0 reached 102,156 calls in the 3-minute budget, 0.41.1
+reached 189,515). It is **not** needed for this fix: once
+the LUT is gone, 0.39.0 builds the engine fine. Keep it a
+separate change so a toolchain regression cannot be
+mistaken for a vendoring regression. Its `TINYGO_SHA256` is
+supplied at merge time per project practice.
 
 ## Acceptance Criteria
 
 - [ ] `tinygo build -target wasm ./cmd/mdsmith-wasm`
-      succeeds with the vendored package, with no interp
-      timeout.
-- [ ] `TestTinyGoWASMArtifactSizeBudget` passes, and the
-      artifact does not grow by the 2.1 MiB the LUT would
-      have added.
-- [ ] The parity test proves vendored and upstream
-      `StringWidth` agree across the full rune range, and
-      fails if the fork's behavior drifts.
-- [ ] CI runs the parity tag in its own job, so the tag
-      cannot rot the way `mdtext_punkt_upstream` did.
+      succeeds with the vendored package, no interp timeout.
+- [ ] `TestTinyGoWASMArtifactSizeBudget` passes and the
+      artifact does not carry the 2.1 MiB the LUT would add.
+- [ ] The regression test proves `RuneWidth` equals
+      `runeWidthNoLUT` across the full rune range and both
+      `eastAsian` settings, and covers a ZWJ emoji, a flag,
+      and a combining sequence through `StringWidth`.
+- [ ] The regression test is untagged and runs in the
+      default `go test ./...`, so it cannot rot the way
+      `mdtext_punkt_upstream` did.
 - [ ] `pkg/runewidth/LICENSE` is the upstream MIT license,
-      unmodified, with copyright intact.
+      unmodified, copyright intact.
 - [ ] `github.com/mattn/go-runewidth` no longer appears in
-      `go.mod` or `go.sum`.
-- [ ] Table formatting output is unchanged: the
-      `tableformat` and `tablefmt` suites pass untouched.
+      `go.mod` or `go.sum`; `uax29/v2` is a direct require.
+- [ ] Any table-formatting output change from the
+      0.0.24 -> 0.0.27 upgrade is captured in regenerated
+      fixtures and reviewed, not silently applied.
 - [ ] `go test ./...` is green.
 - [ ] `go tool -modfile=tools/go.mod golangci-lint run`
       reports no issues.
 - [ ] `mdsmith check .` is green.
 
 [pr777]: https://github.com/jeduden/mdsmith/pull/777
-[sizetest]: ../cmd/mdsmith-wasm/size_test.go
+[gomod]: ../go.mod
 [tablefmt]: ../internal/rules/tablefmt/tablefmt.go
 [parity]: ../internal/release/parity.go
 [tabletest]: ../internal/rules/tableformat/rule_test.go

--- a/plan/2608161754_vendor-runewidth-bump-tinygo.md
+++ b/plan/2608161754_vendor-runewidth-bump-tinygo.md
@@ -169,47 +169,76 @@ the LUT-free fork returns identical widths across all
 
 ## Tasks
 
-1. Spike first: vendor go-runewidth 0.0.27 into
-   `pkg/runewidth/` (non-test `.go` files plus `LICENSE`),
-   rewrite the package path, promote uax29 to a direct
-   `require`, and confirm `tinygo build -target wasm
-   ./cmd/mdsmith-wasm` still times out — establishing the
-   reproduction inside the tree before changing anything.
-   If tinygo instead fails on uax29, stop and re-plan.
-2. Record the upstream version and commit in a package doc
-   comment. Do not copy `go.mod`, `go.sum`, or the
-   benchmark scratch files. Keep the exported API
-   byte-identical so a future re-sync stays a mechanical
-   diff.
-3. Write the regression test first (ordinary test, no build
-   tag): for every rune in `0..0x10FFFF` and both
-   `eastAsian` settings, assert `RuneWidth` equals
-   `runeWidthNoLUT` with the same arguments; add `StringWidth`
-   cases for the emoji mdsmith actually writes — the status
-   set `✅ 🔲 🔳 ⛔ 🤖` (each expected width 2) — plus the
-   uax29 grapheme path (a ZWJ family sequence, a
-   regional-indicator flag, a base+combining sequence). It
-   passes on the as-copied fork and must still pass after
-   step 4 — it guards the removal, it does not drive it.
-4. Delete the eager LUT: remove `strictWidthLUT`, remove
+The work is three phases. Phase 0 is a spike whose result
+gates the other two — do not start Phase 1 until it passes.
+
+### Phase 0 — spike (go / no-go)
+
+One question decides whether the rest of the plan holds:
+does uax29 build under tinygo? Everything else is already
+known — the LUT times out (seen on [PR #777][pr777]'s CI),
+the removal is equivalence-by-construction, and the widths
+are measured. So spend the smallest effort that answers only
+the open question, before writing any of the real change.
+
+1. Vendor go-runewidth 0.0.27 into `pkg/runewidth/` (non-test
+   `.go` files plus `LICENSE`), rewrite the package path, and
+   promote uax29 to a direct `require`.
+2. Run `tinygo build -target wasm ./cmd/mdsmith-wasm` and read
+   which package the interp pass dies in.
+
+The failure location is the gate:
+
+- Timeout in `runewidth` (expected) — the LUT reproduces
+  inside the tree and uax29 compiles. Proceed to Phase 1 on
+  this same branch.
+- Failure in `uax29` — the plan's shape is wrong. Stop.
+  uax29 then needs its own treatment (vendor and patch it
+  too, or keep grapheme clustering off the wasm path), which
+  is a different plan. Do not continue.
+
+### Phase 1 — remove the LUT
+
+3. Record the upstream version and commit in a package doc
+   comment. Do not copy `go.mod`, `go.sum`, or the benchmark
+   scratch files. Keep the exported API byte-identical so a
+   future re-sync stays a mechanical diff.
+4. Write the regression test first (ordinary test, no build
+   tag): for every rune in `0..0x10FFFF` and both `eastAsian`
+   settings, assert `RuneWidth` equals `runeWidthNoLUT` with
+   the same arguments; add `StringWidth` cases for the emoji
+   mdsmith actually writes — the status set `✅ 🔲 🔳 ⛔ 🤖`
+   (each expected width 2) — plus the uax29 grapheme path (a
+   ZWJ family sequence, a regional-indicator flag, a
+   base+combining sequence). It passes on the as-copied fork
+   and must still pass after step 5 — it guards the removal,
+   it does not drive it.
+5. Delete the eager LUT: remove `strictWidthLUT`, remove
    `initStrictWidthLUT`, drop its call from `init`, and
    replace every `strictWidthLUT[k][r]` read with the
    equivalent `runeWidthNoLUT(r, eastAsian, strictEmojiNeutral)`
    call, preserving the exact arguments each read encoded.
    Do not substitute a `sync.Once`: that keeps the 2.1 MiB
    array and only moves the fill to first call.
-5. Repoint the three call sites to `pkg/runewidth` and drop
+6. Confirm the tinygo wasm build now succeeds and
+   `TestTinyGoWASMArtifactSizeBudget` passes — the Phase 0
+   timeout is gone and the 2.1 MiB is no longer in the
+   artifact.
+
+### Phase 2 — integrate and retire the module
+
+7. Repoint the three call sites to `pkg/runewidth` and drop
    `github.com/mattn/go-runewidth` from [go.mod][gomod] and
    `go.sum`. Confirm uax29 is now a direct requirement.
-6. Regenerate the table-formatting golden fixtures if the
-   0.0.24 -> 0.0.27 width changes move any output, and
-   review the diff so the shift is understood and intended,
-   not silently absorbed.
-7. Document the fork and its single divergence (the LUT
+8. Regenerate the table-formatting golden fixtures if the
+   0.0.24 -> 0.0.27 width changes move any output, and review
+   the diff so the shift (flag emoji, say) is understood and
+   intended, not silently absorbed.
+9. Document the fork and its single divergence (the LUT
    removal) in [markdown-library.md][mdlib] or a sibling
    development page, so a re-sync knows the deletion is
    deliberate.
-8. Close [PR #777][pr777] as retired by this work.
+10. Close [PR #777][pr777] as retired by this work.
 
 ## Optional follow-up (not required by this plan)
 

--- a/plan/2608161754_vendor-runewidth-bump-tinygo.md
+++ b/plan/2608161754_vendor-runewidth-bump-tinygo.md
@@ -108,6 +108,39 @@ The archived audit flags a trap to avoid.
 The LUT regression test is an ordinary untagged test in the
 default suite. It always runs, so it cannot rot.
 
+## Performance impact
+
+Removing the LUT is a net win for mdsmith's workload, not a
+regression. The numbers below were measured on this
+machine. They compare 0.0.27 as copied against the same
+code with the LUT deleted.
+
+| Path                           | With LUT | No LUT |
+| ------------------------------ | -------- | ------ |
+| Package `init` (every startup) | 12.7 ms  | 0 ms   |
+| Static array                   | 2.1 MiB  | 0      |
+| `StringWidth`, ASCII cell      | 7.8 ns   | 6.5 ns |
+| `StringWidth`, CJK cell        | 124 ns   | 222 ns |
+| `RuneWidth`, one CJK rune      | 1.4 ns   | 9.1 ns |
+
+The LUT's cost is a fixed 12.7 ms fill at every process
+start, plus 2.1 MiB resident. The CLI starts fresh on every
+invocation, so it pays that on `mdsmith version` and on
+every file with no tables at all. The benefit is roughly
+100 ns saved per CJK table cell. Around 127,000 such cells
+per run are needed just to offset one startup fill.
+
+ASCII content — nearly all Markdown tables — is slightly
+faster without the LUT, because the 2.1 MiB array is a cache
+liability the `r < 0x300` fast path skips. Only wide CJK
+tables are slower, and only in the width step that uax29
+grapheme clustering already dominates.
+
+Against the current pinned 0.0.24, the width path is
+unchanged: 0.0.24 has no LUT either. A parity test confirms
+the LUT-free fork returns identical widths across all
+1,114,112 runes and both East-Asian settings.
+
 ## Tasks
 
 1. Spike first: vendor go-runewidth 0.0.27 into

--- a/plan/2608161754_vendor-runewidth-bump-tinygo.md
+++ b/plan/2608161754_vendor-runewidth-bump-tinygo.md
@@ -141,9 +141,26 @@ so (about 6.5 ns against 8.0 ns per cell across five runs).
 
 mdsmith's own corpus and most Markdown tables are English or
 otherwise ASCII, so this is the case to optimize. The only
-content the LUT helps is wide CJK tables, and only in the
+content the LUT helps is CJK and emoji, and only in the
 per-rune width step that uax29 grapheme clustering already
-dominates. That regression is accepted.
+dominates.
+
+**Emoji specifically, since we write them.** The status
+emoji in plan front matter and the PLAN.md status column —
+`✅ 🔲 🔳 ⛔ 🤖` — measure width 2 in every variant: 0.0.24,
+0.0.27 with the LUT, and 0.0.27 without it. Removing the LUT
+changes no emoji width, which the parity test below proves
+across the whole rune range. So emoji tables do not
+re-align from this change. Per emoji cell the no-LUT path
+costs about 7 ns more, and a 250-row status column adds
+roughly 2 microseconds per format. That is accepted.
+
+One real width change does come from the version bump, not
+the LUT: regional-indicator flags such as `🇺🇸` go from
+width 1 in 0.0.24 to width 2 in 0.0.27, an upstream grapheme
+fix. Any table with flag emoji re-aligns once, by design.
+The regression test pins the status emoji and a flag so this
+behavior is locked and a future re-sync cannot regress it.
 
 Against the current pinned 0.0.24, the width path is
 unchanged: 0.0.24 has no LUT either. A parity test confirms
@@ -167,12 +184,13 @@ the LUT-free fork returns identical widths across all
 3. Write the regression test first (ordinary test, no build
    tag): for every rune in `0..0x10FFFF` and both
    `eastAsian` settings, assert `RuneWidth` equals
-   `runeWidthNoLUT` with the same arguments; add a handful
-   of `StringWidth` cases exercising the uax29 grapheme
-   path (a ZWJ emoji sequence, a regional-indicator flag, a
-   base+combining sequence). It passes on the as-copied
-   fork and must still pass after step 4 — it guards the
-   removal, it does not drive it.
+   `runeWidthNoLUT` with the same arguments; add `StringWidth`
+   cases for the emoji mdsmith actually writes — the status
+   set `✅ 🔲 🔳 ⛔ 🤖` (each expected width 2) — plus the
+   uax29 grapheme path (a ZWJ family sequence, a
+   regional-indicator flag, a base+combining sequence). It
+   passes on the as-copied fork and must still pass after
+   step 4 — it guards the removal, it does not drive it.
 4. Delete the eager LUT: remove `strictWidthLUT`, remove
    `initStrictWidthLUT`, drop its call from `init`, and
    replace every `strictWidthLUT[k][r]` read with the

--- a/plan/2608161754_vendor-runewidth-bump-tinygo.md
+++ b/plan/2608161754_vendor-runewidth-bump-tinygo.md
@@ -1,0 +1,148 @@
+---
+id: 2608161754
+title: >-
+  Vendor go-runewidth as a patched fork and bump tinygo
+  to 0.41.1
+status: "🔲"
+model: sonnet
+summary: >-
+  go-runewidth 0.0.27 builds a 2.1 MiB strictWidthLUT in
+  package init; tinygo's interp pass tries to constant-fold
+  it and times out, so the wasm build fails and the
+  dependency is stuck at 0.0.24. Vendor the library into
+  pkg/runewidth with its MIT LICENSE, drop the eager LUT,
+  and gate the fork with an upstream A/B parity test wired
+  into CI. Also bump the pinned tinygo to 0.41.1.
+depends-on: []
+---
+# Vendor go-runewidth as a patched fork and bump tinygo to 0.41.1
+
+## Goal
+
+Own a patched copy of go-runewidth. The wasm build then
+stops failing on an upstream change mdsmith cannot
+otherwise influence.
+
+## Background
+
+Dependabot [PR #777][pr777] bumps go-runewidth 0.0.24 to
+0.0.27. The `tinygo-wasm` CI job fails on it:
+
+```text
+runewidth.go:118:6: interp: running for more than 3m0s,
+timing out (executed calls: 189515)
+```
+
+The traceback names the cause: `init#1` calls
+`initStrictWidthLUT`. Upstream 0.0.27 added a precomputed
+width lookup table, declared as
+`strictWidthLUT [2][0x110000]byte` and filled in package
+`init`. That is 2,228,224 entries, each derived by calling
+`runeWidthNoLUT`. Tinygo's `interp` pass tries to evaluate
+the whole initializer at compile time and gives up at its
+3-minute budget.
+
+Bumping tinygo alone does not fix it. Measured on CI:
+0.39.0 reached 102,156 interpreted calls in 3 minutes and
+0.41.1 reached 189,515 — roughly 1.85 times faster, against
+a workload of millions of calls. Raising
+`-interp-timeout` would charge every future CI run ten
+minutes or more for a dependency bump that carries no
+security fix.
+
+Two further facts make vendoring the right shape:
+
+- The LUT is a 2.1 MiB static array. The wasm artifact
+  budget in [size_test.go][sizetest] is 8 MiB raw, so the
+  table alone would consume about a quarter of it even if
+  the compile-time problem were solved.
+- mdsmith uses exactly one symbol from the library,
+  `runewidth.StringWidth`, from three call sites:
+  [tablefmt.go][tablefmt], [parity.go][parity], and
+  [rule_test.go][tabletest].
+
+A precedent already exists. [pkg/goldmark][goldmark] is a
+vendored fork carrying its upstream LICENSE, with a
+`goldmark_upstream` build tag that CI exercises through the
+`goldmark-fork-test` job. This plan follows that shape.
+
+It also avoids a known trap. The archived audit records
+that [internal/mdtext/upstreampunct.go][punct] carries a
+`mdtext_punkt_upstream` tag no workflow ever passes, and
+calls it a "silent bit-rot risk". The parity tag added here
+must run in CI from the first commit.
+
+Vendoring also retires [PR #777][pr777] and every future
+dependabot PR for this module, because the `go.mod`
+requirement goes away.
+
+## Tasks
+
+1. Bump the pinned tinygo in [ci.yml][ci] from 0.39.0 to
+   0.41.1. Set `TINYGO_SHA256` to
+   `901fbccffc61adb111656d1f907dfc21b6c499ca841b115866a0d6de2d835fbe`,
+   computed from the 179,764,108-byte release artifact.
+   Comment why the pin is coupled to go-runewidth.
+2. Copy go-runewidth 0.0.27 into `pkg/runewidth/`: the
+   non-test `.go` files plus `LICENSE`. Record the upstream
+   version and commit in a package doc comment. Do not copy
+   `go.mod`, `go.sum`, or the benchmark scratch files.
+3. Rewrite the package clause and any internal imports for
+   the new path. Keep the exported API byte-identical so a
+   future re-sync stays a mechanical diff.
+4. Write the failing parity test first, behind a
+   `runewidth_upstream` build tag: for every rune in
+   `0..0x10FFFF`, assert the vendored `StringWidth` agrees
+   with upstream 0.0.27. It fails until step 5 lands.
+5. Remove the eager LUT from the fork: delete
+   `strictWidthLUT`, delete `initStrictWidthLUT`, drop its
+   call from `init`, and route the strict-width path
+   through `runeWidthNoLUT`. Do not substitute a
+   `sync.Once`: that keeps the 2.1 MiB array and only moves
+   the cost to the first call.
+6. Add a `runewidth-fork-test` job to [ci.yml][ci] running
+   `go test -tags runewidth_upstream ./pkg/runewidth/...`,
+   mirroring `goldmark-fork-test`. This is the step that
+   keeps the fork honest.
+7. Repoint the three call sites to the vendored package and
+   drop `github.com/mattn/go-runewidth` from `go.mod` and
+   `go.sum`.
+8. Record the fork and its divergence in
+   [markdown-library.md][mdlib] or a sibling development
+   page, so the next person to re-sync knows the LUT
+   removal is deliberate.
+9. Close [PR #777][pr777] as retired by this work.
+
+## Acceptance Criteria
+
+- [ ] `tinygo build -target wasm ./cmd/mdsmith-wasm`
+      succeeds with the vendored package, with no interp
+      timeout.
+- [ ] `TestTinyGoWASMArtifactSizeBudget` passes, and the
+      artifact does not grow by the 2.1 MiB the LUT would
+      have added.
+- [ ] The parity test proves vendored and upstream
+      `StringWidth` agree across the full rune range, and
+      fails if the fork's behavior drifts.
+- [ ] CI runs the parity tag in its own job, so the tag
+      cannot rot the way `mdtext_punkt_upstream` did.
+- [ ] `pkg/runewidth/LICENSE` is the upstream MIT license,
+      unmodified, with copyright intact.
+- [ ] `github.com/mattn/go-runewidth` no longer appears in
+      `go.mod` or `go.sum`.
+- [ ] Table formatting output is unchanged: the
+      `tableformat` and `tablefmt` suites pass untouched.
+- [ ] `go test ./...` is green.
+- [ ] `go tool -modfile=tools/go.mod golangci-lint run`
+      reports no issues.
+- [ ] `mdsmith check .` is green.
+
+[pr777]: https://github.com/jeduden/mdsmith/pull/777
+[sizetest]: ../cmd/mdsmith-wasm/size_test.go
+[tablefmt]: ../internal/rules/tablefmt/tablefmt.go
+[parity]: ../internal/release/parity.go
+[tabletest]: ../internal/rules/tableformat/rule_test.go
+[goldmark]: ../pkg/goldmark/markdown.go
+[punct]: ../internal/mdtext/upstreampunct.go
+[ci]: ../.github/workflows/ci.yml
+[mdlib]: ../docs/development/markdown-library.md


### PR DESCRIPTION
Adds [plan/2608161754](plan/2608161754_vendor-runewidth-bump-tinygo.md) and regenerates `PLAN.md`.

Plan only — no code changes. It supersedes #777, which cannot pass CI as written.

**Why vendor rather than bump.** go-runewidth 0.0.27 declares `strictWidthLUT [2][0x110000]byte` and fills all 2,228,224 entries in package `init`. tinygo's `interp` pass tries to constant-fold that at compile time and gives up at its 3-minute budget. Bumping tinygo does not fix it — measured on CI, 0.39.0 reached 102,156 interpreted calls and 0.41.1 reached 189,515, roughly 1.85x faster against a workload of millions.

The LUT is also 2.1 MiB of static array against an 8 MiB wasm budget, so solving only the compile-time problem would still cost a quarter of the budget.

mdsmith uses exactly one symbol, `runewidth.StringWidth`, from three call sites — so the fork surface is small and the divergence is one deletion.

**Shape.** Follows the existing `pkg/goldmark` fork: upstream LICENSE at the package root, plus an A/B parity test behind a build tag. The plan explicitly wires that tag into a CI job, because the archived audit records `mdtext_punkt_upstream` as a tag no workflow runs and calls it a silent bit-rot risk.

Vendoring also retires #777 and future dependabot PRs for this module, since the `go.mod` requirement goes away.