### PR TITLE
ci(tinygo): bump pinned tinygo 0.39.0 → 0.41.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -559,9 +559,16 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Install tinygo (checksum-pinned .deb)
+        # 0.41.1 for the newer toolchain and LLVM 20 — its interp pass is
+        # ~1.85x faster than 0.39.0 (measured on CI: 102,156 vs 189,515
+        # calls in the 3-minute budget). Not required by the go-runewidth
+        # vendoring (plan 2608161754): once the eager LUT is gone, 0.39.0
+        # builds the engine fine. Kept a separate bump so a toolchain
+        # regression is not mistaken for a vendoring regression.
+        # SHA256 computed from the 179,764,108-byte amd64 .deb.
         env:
-          TINYGO_VERSION: "0.39.0"
-          TINYGO_SHA256: "775f15974e35059c8f3a141266bd9d293b5d556a3e44d5e6356c5602e9f386ab"
+          TINYGO_VERSION: "0.41.1"
+          TINYGO_SHA256: "901fbccffc61adb111656d1f907dfc21b6c499ca841b115866a0d6de2d835fbe"
         run: |
           url="https://github.com/tinygo-org/tinygo/releases/download/v${TINYGO_VERSION}/tinygo_${TINYGO_VERSION}_amd64.deb"
           curl -fsSL -o /tmp/tinygo.deb "$url"


### PR DESCRIPTION
The optional follow-up from [plan/2608161754](plan/2608161754_vendor-runewidth-bump-tinygo.md) (merged in #807), kept separate as the plan specifies.

Bumps the `tinygo-wasm` CI job's pinned toolchain from 0.39.0 to 0.41.1:

- Newer toolchain, LLVM 20.
- ~1.85× faster `interp` pass (measured on CI: 0.39.0 reached 102,156 calls in the 3-minute budget, 0.41.1 reached 189,515).

Independent of the vendoring fix — once the eager LUT was removed, 0.39.0 builds the engine fine. Separate so a toolchain regression can't be mistaken for a vendoring regression.

`TINYGO_SHA256` recomputed from the 179,764,108-byte v0.41.1 `amd64` .deb: `901fbccffc61adb111656d1f907dfc21b6c499ca841b115866a0d6de2d835fbe`.

**Gate to watch:** `tinygo-wasm` (must build green on 0.41.1) and `zizmor` (workflow lint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)