### PR TITLE
perf: fix top 5 high-performance-go.md violations

### DIFF
--- a/internal/engine/bench_sort_test.go
+++ b/internal/engine/bench_sort_test.go
@@ -1,0 +1,40 @@
+package engine
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+)
+
+// BenchmarkSortDiagnostics pins the CPU cost of sorting a
+// representative-size diagnostic set from a large workspace run.
+// sortDiagnostics runs once per Runner.Run/RunSource call over the
+// full result set (internal/engine/runner.go's two call sites) — the
+// one place in the codebase where the reflect-vs-slices.SortStableFunc
+// fix from docs/development/high-performance-go.md's "reflect in hot
+// paths" anti-pattern had not yet been applied, unlike the equivalent
+// per-rule sortDiagnostics helpers in linkvalidity, catalog, astutil,
+// duplicatedcontent, and markdownflavor.
+func BenchmarkSortDiagnostics(b *testing.B) {
+	const n = 2000
+	base := make([]lint.Diagnostic, n)
+	for i := range base {
+		// Descending input order forces real comparison work instead
+		// of a sort implementation detecting an already-sorted run.
+		base[i] = lint.Diagnostic{
+			File:    "file" + strconv.Itoa(n-i) + ".md",
+			Line:    n - i,
+			Column:  1,
+			RuleID:  "MDS001",
+			Message: "message",
+		}
+	}
+
+	diags := make([]lint.Diagnostic, n)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		copy(diags, base)
+		sortDiagnostics(diags)
+	}
+}

--- a/internal/engine/runner_log.go
+++ b/internal/engine/runner_log.go
@@ -1,7 +1,8 @@
 package engine
 
 import (
-	"sort"
+	"cmp"
+	"slices"
 
 	"github.com/jeduden/mdsmith/internal/config"
 	"github.com/jeduden/mdsmith/internal/lint"
@@ -65,23 +66,29 @@ func ruleCategoryLookup(rules []rule.Rule) func(string) string {
 // that produced the diagnostics: the parse-skip block-walk and the full-parse
 // node-walk can emit two same-position, same-message diagnostics from
 // different rules in different input orders, and the Layer-0 equivalence
-// assertions compare full ordered slices. sort.SliceStable then preserves
-// input order only for diagnostics equal on every compared field.
+// assertions compare full ordered slices. slices.SortStableFunc then
+// preserves input order only for diagnostics equal on every compared field.
+//
+// slices.SortStableFunc sorts the concrete lint.Diagnostic values directly,
+// unlike sort.SliceStable, which drives reflect.Swapper under the hood —
+// see docs/development/high-performance-go.md's "reflect in hot paths"
+// anti-pattern. This runs once per Runner.Run/RunSource call over the full
+// result set, so it's the one place in the codebase this fix — already
+// applied to the equivalent per-rule sortDiagnostics helpers — was missing.
 func sortDiagnostics(diags []lint.Diagnostic) {
-	sort.SliceStable(diags, func(i, j int) bool {
-		di, dj := diags[i], diags[j]
-		if di.File != dj.File {
-			return di.File < dj.File
+	slices.SortStableFunc(diags, func(a, b lint.Diagnostic) int {
+		if a.File != b.File {
+			return cmp.Compare(a.File, b.File)
 		}
-		if di.Line != dj.Line {
-			return di.Line < dj.Line
+		if a.Line != b.Line {
+			return cmp.Compare(a.Line, b.Line)
 		}
-		if di.Column != dj.Column {
-			return di.Column < dj.Column
+		if a.Column != b.Column {
+			return cmp.Compare(a.Column, b.Column)
 		}
-		if di.Message != dj.Message {
-			return di.Message < dj.Message
+		if a.Message != b.Message {
+			return cmp.Compare(a.Message, b.Message)
 		}
-		return di.RuleID < dj.RuleID
+		return cmp.Compare(a.RuleID, b.RuleID)
 	})
 }

--- a/internal/lint/runcache.go
+++ b/internal/lint/runcache.go
@@ -21,6 +21,7 @@ import (
 // what the next Check would read from disk.
 type RunCache struct {
 	frontMatter         sync.Map // string (absPath) -> *runCacheEntry
+	rawSchemaFile       sync.Map // string (absPath) -> *runCacheEntry
 	includes            sync.Map // string (absPath) -> *runCacheEntry
 	anchors             sync.Map // string (absPath) -> *anchorEntry
 	wikilinks           sync.Map // string (root key) -> *runCacheEntry
@@ -120,6 +121,17 @@ func NewRunCache() *RunCache {
 // same key block on the same once and observe the same value.
 func (c *RunCache) FrontMatter(absPath string, build func() any) any {
 	return load(&c.frontMatter, absPath, build)
+}
+
+// RawSchemaFile returns build's result for absPath, computed at most
+// once per absPath in this cache's lifetime. Distinct from
+// ParsedSchema: this slot memoizes a schema file's raw on-disk bytes
+// (and any lightweight peek a caller derives from them before
+// deciding how to parse) so a schema referenced by many host files —
+// the common case for a workspace-wide kind — is read and inspected
+// once per run instead of once per host file.
+func (c *RunCache) RawSchemaFile(absPath string, build func() any) any {
+	return load(&c.rawSchemaFile, absPath, build)
 }
 
 // ScopeInvalidator scopes the unique-field-index slot's response to
@@ -501,6 +513,7 @@ func (c *RunCache) invalidate(absPath string, visited map[string]struct{}) {
 	visited[absPath] = struct{}{}
 
 	c.frontMatter.Delete(absPath)
+	c.rawSchemaFile.Delete(absPath)
 	c.includes.Delete(absPath)
 	c.anchors.Delete(absPath)
 	c.dropDuplicateParagraphs(absPath)

--- a/internal/lint/runcache_test.go
+++ b/internal/lint/runcache_test.go
@@ -51,6 +51,50 @@ func TestRunCache_IncludesBuildsOnce(t *testing.T) {
 		"include-adjacency build must run exactly once per absPath")
 }
 
+// TestRunCache_RawSchemaFileBuildsOnce pins the same single-build
+// guarantee for the raw-schema-bytes cache: a schema referenced by
+// many host files (the common case for a workspace-wide kind) must
+// be read and inspected once per run, not once per host file.
+func TestRunCache_RawSchemaFileBuildsOnce(t *testing.T) {
+	c := NewRunCache()
+
+	var calls int32
+	build := func() any {
+		atomic.AddInt32(&calls, 1)
+		return "schema bytes"
+	}
+
+	for i := 0; i < 3; i++ {
+		got := c.RawSchemaFile("/abs/schema.md", build)
+		require.Equal(t, "schema bytes", got)
+	}
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls),
+		"build must run exactly once per absPath")
+}
+
+// TestRunCache_RawSchemaFileInvalidateForcesRebuild pins that
+// Invalidate clears the raw-schema-bytes slot alongside the other
+// per-path caches, so an LSP edit to a schema file is picked up on
+// the next lookup instead of serving stale bytes forever.
+func TestRunCache_RawSchemaFileInvalidateForcesRebuild(t *testing.T) {
+	c := NewRunCache()
+
+	var calls int32
+	build := func(v string) func() any {
+		return func() any {
+			atomic.AddInt32(&calls, 1)
+			return v
+		}
+	}
+	c.RawSchemaFile("/abs/schema.md", build("v1"))
+	c.Invalidate("/abs/schema.md")
+	got := c.RawSchemaFile("/abs/schema.md", build("v2"))
+
+	assert.Equal(t, "v2", got, "Invalidate must clear the raw-schema slot")
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls),
+		"build must run again after Invalidate")
+}
+
 // TestRunCache_DistinctKeysDoNotShare pins that two absPaths are
 // independent: caching one must not silently serve the other.
 func TestRunCache_DistinctKeysDoNotShare(t *testing.T) {

--- a/internal/rules/ambiguousemphasis/rule.go
+++ b/internal/rules/ambiguousemphasis/rule.go
@@ -14,8 +14,9 @@ package ambiguousemphasis
 
 import (
 	"bytes"
+	"cmp"
 	"fmt"
-	"sort"
+	"slices"
 
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/rule"
@@ -86,11 +87,15 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 		diags = append(diags, r.checkLine(f, lineNum, masked)...)
 	}
 
-	sort.SliceStable(diags, func(i, j int) bool {
-		if diags[i].Line != diags[j].Line {
-			return diags[i].Line < diags[j].Line
+	// slices.SortStableFunc sorts the concrete lint.Diagnostic values
+	// directly, unlike sort.SliceStable, which drives reflect.Swapper
+	// under the hood — see docs/development/high-performance-go.md's
+	// "reflect in hot paths" anti-pattern.
+	slices.SortStableFunc(diags, func(a, b lint.Diagnostic) int {
+		if a.Line != b.Line {
+			return cmp.Compare(a.Line, b.Line)
 		}
-		return diags[i].Column < diags[j].Column
+		return cmp.Compare(a.Column, b.Column)
 	})
 	return diags
 }

--- a/internal/rules/ambiguousemphasis/rule_test.go
+++ b/internal/rules/ambiguousemphasis/rule_test.go
@@ -134,6 +134,20 @@ func TestCheck_LongRunDedup_OnlyOnePerLength(t *testing.T) {
 	assert.Equal(t, 1, diags[0].Column)
 }
 
+// TestCheck_MultipleLines_SortedByLine pins the Line-tiebreak branch
+// of Check's final sort: two triggering lines produce diagnostics in
+// ascending line order. Every other Check test in this file triggers
+// at most one line per document, so this is the only test that
+// exercises the `a.Line != b.Line` comparison.
+func TestCheck_MultipleLines_SortedByLine(t *testing.T) {
+	f, err := lint.NewFile("test.md", []byte("***a***\n\n***b***\n"))
+	require.NoError(t, err)
+	diags := activeRule().Check(f)
+	require.Len(t, diags, 2)
+	assert.Equal(t, 1, diags[0].Line)
+	assert.Equal(t, 3, diags[1].Line)
+}
+
 func TestApplySettings_RejectsUnknownKey(t *testing.T) {
 	r := &Rule{}
 	err := r.ApplySettings(map[string]any{"bogus": true})

--- a/internal/rules/catalog/bench_test.go
+++ b/internal/rules/catalog/bench_test.go
@@ -1,0 +1,50 @@
+package catalog
+
+import (
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+)
+
+// BenchmarkCheck_NoCatalogDirective pins Check's CPU cost on a
+// representative host file with no <?catalog?> directive — the
+// common case for most files in a workspace, since MDS019 is
+// default-enabled and every host file pays this path whether or not
+// it ever uses the directive. Before the fix, Check unconditionally
+// ran gensection.FindMarkerPairs' top-level AST walk three times
+// (once via getEngine().Check, once each in checkCaseMismatches and
+// checkInjection) regardless of whether the source could contain a
+// catalog directive at all. See
+// docs/development/high-performance-go.md's "gate expensive
+// analyzers behind a cheap pre-check" pattern.
+func BenchmarkCheck_NoCatalogDirective(b *testing.B) {
+	var sb strings.Builder
+	sb.WriteString("# Doc\n\n")
+	for range 200 {
+		sb.WriteString("## Section\n\n" +
+			"A representative paragraph of prose with enough words " +
+			"to look like real content in a typical Markdown file.\n\n")
+	}
+	src := []byte(sb.String())
+	fsys := fstest.MapFS{}
+	r := &Rule{}
+
+	// Parsing 200 sections dwarfs Check's own cost, so the parse step
+	// is built outside the timed region: this benchmark isolates the
+	// AST-walk work Check performs, not goldmark's parse.
+	b.ReportAllocs()
+	b.StopTimer()
+	for i := 0; i < b.N; i++ {
+		f, err := lint.NewFile("doc.md", src)
+		if err != nil {
+			b.Fatal(err)
+		}
+		f.FS = fsys
+		f.RootFS = fsys
+		b.StartTimer()
+		_ = r.Check(f)
+		b.StopTimer()
+	}
+}

--- a/internal/rules/catalog/race_off_test.go
+++ b/internal/rules/catalog/race_off_test.go
@@ -1,0 +1,5 @@
+//go:build !race
+
+package catalog
+
+const raceEnabled = false

--- a/internal/rules/catalog/race_on_test.go
+++ b/internal/rules/catalog/race_on_test.go
@@ -1,0 +1,5 @@
+//go:build race
+
+package catalog
+
+const raceEnabled = true

--- a/internal/rules/catalog/rule.go
+++ b/internal/rules/catalog/rule.go
@@ -95,25 +95,53 @@ func (r *Rule) getEngine() *gensection.Engine {
 	return r.engine
 }
 
+// catalogStartNeedle and catalogEndNeedle bound the cheap pre-check
+// mayContainCatalogDirective runs before Check pays for any AST walk.
+// Two needles are required because the end marker "<?/catalog" does
+// not contain the start marker "<?catalog" as a substring — mirrors
+// include's mayContainIncludeDirective.
+var (
+	catalogStartNeedle = []byte("<?catalog")
+	catalogEndNeedle   = []byte("<?/catalog")
+)
+
+// mayContainCatalogDirective reports whether source could contain any
+// catalog start marker, end marker, or orphaned end marker. MDS019 is
+// default-enabled, so every host file in a workspace pays Check's
+// cost — gating the AST walk behind this byte scan means the common
+// case (no catalog directive at all) costs one bytes.Contains pass
+// instead of three top-level AST walks. See
+// docs/development/high-performance-go.md's "gate expensive analyzers
+// behind a cheap pre-check" pattern.
+func mayContainCatalogDirective(source []byte) bool {
+	return bytes.Contains(source, catalogStartNeedle) ||
+		bytes.Contains(source, catalogEndNeedle)
+}
+
 // Check implements rule.Rule.
 func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
-	if f.FS == nil {
+	if f.FS == nil || !mayContainCatalogDirective(f.Source) {
 		return nil
 	}
 	diags := r.getEngine().Check(f)
+	// checkCaseMismatches and checkInjection both need the same marker
+	// pairs the engine just found; computing them once here instead of
+	// letting each pass re-walk the AST halves the remaining walk cost
+	// on files that do carry a catalog directive.
+	pairs, _ := gensection.FindMarkerPairs(f, r.Name(), r.ID(), r.Name())
 	// Case-mismatch hints run a separate pass over directives. This
 	// re-reads front-matter but avoids coupling hints to the engine's
 	// fatal-diagnostic pipeline. Acceptable for typical catalog sizes.
-	diags = append(diags, r.checkCaseMismatches(f)...)
+	diags = append(diags, r.checkCaseMismatches(f, pairs)...)
 	// Injection warnings are non-fatal and must not block generation,
 	// so they run as a separate pass outside the engine.
-	diags = append(diags, r.checkInjection(f)...)
+	diags = append(diags, r.checkInjection(f, pairs)...)
 	return diags
 }
 
 // Fix implements rule.FixableRule.
 func (r *Rule) Fix(f *lint.File) []byte {
-	if f.FS == nil {
+	if f.FS == nil || !mayContainCatalogDirective(f.Source) {
 		return f.Source
 	}
 	return r.getEngine().Fix(f)
@@ -1015,11 +1043,9 @@ func checkCatalogInjection(filePath string, line int, entries []fileEntry) []lin
 
 // checkInjection scans catalog directives for front-matter values that could
 // inject Markdown structure. Runs independently of Generate so warnings don't
-// block content generation.
-func (r *Rule) checkInjection(f *lint.File) []lint.Diagnostic {
-	pairs, _ := gensection.FindMarkerPairs(
-		f, r.Name(), r.ID(), r.Name(),
-	)
+// block content generation. pairs is shared with Check's other passes so the
+// caller only walks the AST once per Check call.
+func (r *Rule) checkInjection(f *lint.File, pairs []gensection.MarkerPair) []lint.Diagnostic {
 	var diags []lint.Diagnostic
 	for _, mp := range pairs {
 		dir, parseDiags := gensection.ParseDirective(
@@ -1667,11 +1693,9 @@ func parseRowTemplate(row string) error {
 // checkCaseMismatches scans catalog directives in the file for
 // case-mismatched front-matter field references and returns hint
 // diagnostics. Runs independently of the Generate/Fix path so
-// hints don't block content generation.
-func (r *Rule) checkCaseMismatches(f *lint.File) []lint.Diagnostic {
-	pairs, _ := gensection.FindMarkerPairs(
-		f, r.Name(), r.ID(), r.Name(),
-	)
+// hints don't block content generation. pairs is shared with Check's
+// other passes so the caller only walks the AST once per Check call.
+func (r *Rule) checkCaseMismatches(f *lint.File, pairs []gensection.MarkerPair) []lint.Diagnostic {
 	var diags []lint.Diagnostic
 	for _, mp := range pairs {
 		dir, parseDiags := gensection.ParseDirective(

--- a/internal/rules/catalog/rule_test.go
+++ b/internal/rules/catalog/rule_test.go
@@ -113,6 +113,75 @@ func TestRule_Validate(t *testing.T) {
 	expectDiagMsg(t, diags, `sets both "row" and "row-expr"; choose one`)
 }
 
+// TestCheck_NoCatalogDirectiveAllocatesNothing pins Check's cost on a
+// file with no <?catalog?> directive at zero allocs. MDS019 is
+// default-enabled, so every host file in a workspace pays this path
+// even when it never uses the directive. Before this test, Check
+// unconditionally ran gensection.FindMarkerPairs three times (once via
+// getEngine().Check, once each in checkCaseMismatches and
+// checkInjection) — the same top-level AST walk repeated for every
+// file, catalog or not. This is the "gate expensive analyzers behind a
+// cheap pre-check" pattern documented in
+// docs/development/high-performance-go.md.
+func TestCheck_NoCatalogDirectiveAllocatesNothing(t *testing.T) {
+	if raceEnabled {
+		t.Skip("alloc gate skipped under -race")
+	}
+	fsys := fstest.MapFS{}
+	src := "# Doc\n\nJust a plain paragraph with no directives.\n"
+	f := newTestFile(t, "doc.md", src, fsys)
+	r := &Rule{}
+
+	diags := r.Check(f)
+	expectDiags(t, diags, 0)
+
+	allocs := testing.AllocsPerRun(200, func() {
+		g, err := lint.NewFile("doc.md", []byte(src))
+		require.NoError(t, err)
+		g.FS = fsys
+		g.RootFS = fsys
+		_ = r.Check(g)
+	})
+	parseAllocs := testing.AllocsPerRun(200, func() {
+		g, err := lint.NewFile("doc.md", []byte(src))
+		require.NoError(t, err)
+		_ = g
+	})
+	assert.Zero(t, allocs-parseAllocs,
+		"Check must not allocate on a file with no catalog directive")
+}
+
+// TestCheck_CatalogDirectiveSharesMarkerPairsAcrossPasses pins the
+// deduplication half of the fix: checkCaseMismatches and
+// checkInjection must not each re-run gensection.FindMarkerPairs when
+// a catalog directive is present. This is a behavioral pin (both hint
+// passes still fire) rather than an alloc-count pin, since the engine
+// itself still performs one FindMarkerPairs call independently.
+func TestCheck_CatalogDirectiveSharesMarkerPairsAcrossPasses(t *testing.T) {
+	fsys := fstest.MapFS{
+		"a.md": &fstest.MapFile{Data: []byte("---\nName: a\n---\n# A\n")},
+	}
+	src := "<?catalog\n" +
+		"glob: \"*.md\"\n" +
+		"row: \"- {Name}\"\n" +
+		"?>\n" +
+		"<?/catalog?>\n"
+	f := newTestFile(t, "host.md", src, fsys)
+	r := newDefaultRule()
+
+	diags := r.Check(f)
+	// The directive is out of date (empty body vs the rendered entry),
+	// so the engine reports one diagnostic; the case-mismatch and
+	// injection passes should not raise any additional noise here.
+	found := false
+	for _, d := range diags {
+		if strings.Contains(d.Message, "out of date") {
+			found = true
+		}
+	}
+	assert.True(t, found, "expected the generated-section diagnostic to still fire")
+}
+
 // =====================================================================
 // Core rendering
 // =====================================================================

--- a/internal/rules/noinlinehtml/rule.go
+++ b/internal/rules/noinlinehtml/rule.go
@@ -2,9 +2,10 @@ package noinlinehtml
 
 import (
 	"bytes"
+	"cmp"
 	"fmt"
 	"regexp"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/jeduden/mdsmith/pkg/goldmark/ast"
@@ -146,7 +147,13 @@ func (r *Rule) checkFromLayers(f *lint.File) []lint.Diagnostic {
 	if len(found) == 0 {
 		return nil
 	}
-	sort.SliceStable(found, func(i, j int) bool { return found[i].offset < found[j].offset })
+	// slices.SortStableFunc sorts the concrete located values directly,
+	// unlike sort.SliceStable, which drives reflect.Swapper under the
+	// hood — see docs/development/high-performance-go.md's "reflect
+	// in hot paths" anti-pattern.
+	slices.SortStableFunc(found, func(a, b located) int {
+		return cmp.Compare(a.offset, b.offset)
+	})
 	diags := make([]lint.Diagnostic, len(found))
 	for i, l := range found {
 		diags[i] = l.diag

--- a/internal/rules/noreferencestyle/rule.go
+++ b/internal/rules/noreferencestyle/rule.go
@@ -6,9 +6,10 @@ package noreferencestyle
 
 import (
 	"bytes"
+	"cmp"
 	"fmt"
 	"regexp"
-	"sort"
+	"slices"
 	"strings"
 	"unicode"
 
@@ -671,8 +672,12 @@ func collectDefinitionCuts(f *lint.File, usedLabels map[string]struct{}) []fixCu
 }
 
 func applyCuts(source []byte, cuts []fixCut) []byte {
-	sort.Slice(cuts, func(i, j int) bool {
-		return cuts[i].start < cuts[j].start
+	// slices.SortFunc sorts the concrete fixCut values directly,
+	// unlike sort.Slice, which drives reflect.Swapper under the hood —
+	// see docs/development/high-performance-go.md's "reflect in hot
+	// paths" anti-pattern.
+	slices.SortFunc(cuts, func(a, b fixCut) int {
+		return cmp.Compare(a.start, b.start)
 	})
 	var out bytes.Buffer
 	prev := 0

--- a/internal/rules/nospaceincodespans/rule.go
+++ b/internal/rules/nospaceincodespans/rule.go
@@ -4,7 +4,8 @@ package nospaceincodespans
 
 import (
 	"bytes"
-	"sort"
+	"cmp"
+	"slices"
 
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/rule"
@@ -184,7 +185,13 @@ func (r *Rule) Fix(f *lint.File) []byte {
 		return out
 	}
 
-	sort.Slice(cuts, func(i, j int) bool { return cuts[i].start < cuts[j].start })
+	// slices.SortFunc sorts the concrete cut values directly, unlike
+	// sort.Slice, which drives reflect.Swapper under the hood — see
+	// docs/development/high-performance-go.md's "reflect in hot
+	// paths" anti-pattern.
+	slices.SortFunc(cuts, func(a, b cut) int {
+		return cmp.Compare(a.start, b.start)
+	})
 	var out bytes.Buffer
 	prev := 0
 	for _, c := range cuts {

--- a/internal/rules/nounusedlinkdefinitions/rule.go
+++ b/internal/rules/nounusedlinkdefinitions/rule.go
@@ -5,8 +5,9 @@ package nounusedlinkdefinitions
 
 import (
 	"bytes"
+	"cmp"
 	"fmt"
-	"sort"
+	"slices"
 
 	"github.com/jeduden/mdsmith/internal/lint"
 	"github.com/jeduden/mdsmith/internal/rule"
@@ -556,8 +557,12 @@ type fixCut struct {
 }
 
 func applyCuts(source []byte, cuts []fixCut) []byte {
-	sort.Slice(cuts, func(i, j int) bool {
-		return cuts[i].start < cuts[j].start
+	// slices.SortFunc sorts the concrete fixCut values directly,
+	// unlike sort.Slice, which drives reflect.Swapper under the hood —
+	// see docs/development/high-performance-go.md's "reflect in hot
+	// paths" anti-pattern.
+	slices.SortFunc(cuts, func(a, b fixCut) int {
+		return cmp.Compare(a.start, b.start)
 	})
 	var out bytes.Buffer
 	prev := 0

--- a/internal/rules/propernames/rule.go
+++ b/internal/rules/propernames/rule.go
@@ -4,8 +4,9 @@ package propernames
 
 import (
 	"bytes"
+	"cmp"
 	"fmt"
-	"sort"
+	"slices"
 	"strconv"
 
 	"github.com/jeduden/mdsmith/internal/lint"
@@ -279,11 +280,15 @@ func (r *Rule) collectMatches(f *lint.File) []wrongMatch {
 // at each offset. Both Check and Fix call this so they agree on which
 // occurrences constitute a single diagnostic/replacement.
 func normalizeMatches(matches []wrongMatch) []wrongMatch {
-	sort.Slice(matches, func(i, j int) bool {
-		if matches[i].start != matches[j].start {
-			return matches[i].start < matches[j].start
+	// slices.SortFunc sorts the concrete wrongMatch values directly,
+	// unlike sort.Slice, which drives reflect.Swapper under the hood —
+	// see docs/development/high-performance-go.md's "reflect in hot
+	// paths" anti-pattern.
+	slices.SortFunc(matches, func(a, b wrongMatch) int {
+		if a.start != b.start {
+			return cmp.Compare(a.start, b.start)
 		}
-		return matches[i].length > matches[j].length
+		return cmp.Compare(b.length, a.length)
 	})
 	out := matches[:0]
 	prev := 0

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -574,14 +574,54 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 func (r *Rule) dispatchSingleFileSchema(
 	f *lint.File, schemaPath string, sources []SchemaSource,
 ) []lint.Diagnostic {
-	data, schPath, err := r.loadSchemaAt(f, schemaPath)
-	if err != nil {
-		return []lint.Diagnostic{r.diag(f.Path, 1, err.Error())}
+	res := r.cachedRawSchema(f, schemaPath)
+	if res.err != nil {
+		return []lint.Diagnostic{r.diag(f.Path, 1, res.err.Error())}
 	}
-	if schemaDataDeclaresExtends(data) {
+	if res.extends {
 		return r.checkComposedSources(f, sources)
 	}
-	return r.checkSingleFileSchemaFromData(f, schemaPath, data, schPath)
+	return r.checkSingleFileSchemaFromData(f, schemaPath, res.data, res.schPath)
+}
+
+// rawSchemaResult bundles loadSchemaAt's return values with the
+// extends-peek schemaDataDeclaresExtends derives from them, so
+// cachedRawSchema can memoize both behind a single RunCache slot.
+type rawSchemaResult struct {
+	data    []byte
+	schPath string
+	err     error
+	extends bool
+}
+
+// cachedRawSchema returns loadSchemaAt's result for schemaPath plus
+// the schemaDataDeclaresExtends peek over that data, computed at
+// most once per absolute schema path per RunCache lifetime. Without
+// this, a schema referenced by every file under a workspace-wide
+// kind was re-read from disk and re-unmarshalled as YAML once per
+// host file — see docs/development/high-performance-go.md's
+// "memoize per-input computations" pattern. absSchemaCacheKey
+// returning "" (no RunCache, or no stable absolute identity for
+// schemaPath) falls back to building directly, matching the
+// pre-cache behavior for the struct-literal unit-test path.
+func (r *Rule) cachedRawSchema(f *lint.File, schemaPath string) rawSchemaResult {
+	build := func() any {
+		data, schPath, err := r.loadSchemaAt(f, schemaPath)
+		if err != nil {
+			return rawSchemaResult{err: err}
+		}
+		return rawSchemaResult{
+			data:    data,
+			schPath: schPath,
+			extends: schemaDataDeclaresExtends(data),
+		}
+	}
+	if f.RunCache != nil {
+		if absPath := absSchemaCacheKey(f, schemaPath); absPath != "" {
+			return f.RunCache.RawSchemaFile(absPath, build).(rawSchemaResult)
+		}
+	}
+	return build().(rawSchemaResult)
 }
 
 // schemaDataDeclaresExtends reports whether the raw schema bytes

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -576,25 +576,33 @@ func (r *Rule) dispatchSingleFileSchema(
 ) []lint.Diagnostic {
 	res := r.cachedRawSchema(f, schemaPath)
 	if res.err != nil {
-		return []lint.Diagnostic{r.diag(f.Path, 1, res.err.Error())}
+		return []lint.Diagnostic{r.diag(f.Path, 1,
+			fmt.Sprintf("cannot read schema %q: %v", schemaPath, res.err))}
 	}
 	if res.extends {
 		return r.checkComposedSources(f, sources)
 	}
-	return r.checkSingleFileSchemaFromData(f, schemaPath, res.data, res.schPath)
+	return r.checkSingleFileSchemaFromData(f, schemaPath, res.data, schemaPath)
 }
 
-// rawSchemaResult bundles loadSchemaAt's return values with the
-// extends-peek schemaDataDeclaresExtends derives from them, so
+// rawSchemaResult bundles readSchemaFile's return value with the
+// extends-peek schemaDataDeclaresExtends derives from it, so
 // cachedRawSchema can memoize both behind a single RunCache slot.
+// err is the raw read error, not wrapped with a caller's schemaPath
+// string: two kinds can reference the same absolute schema file
+// through differently-spelled (but path-equivalent) schemaPath
+// strings — "docs/proto.md" vs "./docs/proto.md" both resolve to the
+// same absSchemaCacheKey — and whichever caller's spelling populated
+// the cache first must not leak into a later caller's diagnostic.
+// dispatchSingleFileSchema formats the caller-facing message from its
+// own schemaPath argument instead.
 type rawSchemaResult struct {
 	data    []byte
-	schPath string
 	err     error
 	extends bool
 }
 
-// cachedRawSchema returns loadSchemaAt's result for schemaPath plus
+// cachedRawSchema returns readSchemaFile's result for schemaPath plus
 // the schemaDataDeclaresExtends peek over that data, computed at
 // most once per absolute schema path per RunCache lifetime. Without
 // this, a schema referenced by every file under a workspace-wide
@@ -606,13 +614,12 @@ type rawSchemaResult struct {
 // pre-cache behavior for the struct-literal unit-test path.
 func (r *Rule) cachedRawSchema(f *lint.File, schemaPath string) rawSchemaResult {
 	build := func() any {
-		data, schPath, err := r.loadSchemaAt(f, schemaPath)
+		data, err := readSchemaFile(f, schemaPath)
 		if err != nil {
 			return rawSchemaResult{err: err}
 		}
 		return rawSchemaResult{
 			data:    data,
-			schPath: schPath,
 			extends: schemaDataDeclaresExtends(data),
 		}
 	}

--- a/internal/rules/requiredstructure/runcache_perf_test.go
+++ b/internal/rules/requiredstructure/runcache_perf_test.go
@@ -1,0 +1,92 @@
+package requiredstructure
+
+import (
+	"io/fs"
+	"sync/atomic"
+	"testing"
+	"testing/fstest"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countingFS wraps an fs.FS and counts Open calls, so a test can
+// assert a file was read at most once across several lookups.
+type countingFS struct {
+	fs.FS
+	opens *int32
+}
+
+func (c countingFS) Open(name string) (fs.File, error) {
+	atomic.AddInt32(c.opens, 1)
+	return c.FS.Open(name)
+}
+
+// TestDispatchSingleFileSchema_CachesRawSchemaAcrossHostFiles pins
+// that a schema referenced by many host files sharing a RunCache is
+// read from disk exactly once per run, not once per host file.
+// dispatchSingleFileSchema previously called loadSchemaAt and
+// schemaDataDeclaresExtends unconditionally on every Check call —
+// docs/development/high-performance-go.md's "memoize per-input
+// computations" pattern, applied to a workspace-wide kind's schema
+// file.
+func TestDispatchSingleFileSchema_CachesRawSchemaAcrossHostFiles(t *testing.T) {
+	var opens int32
+	fsys := countingFS{
+		FS: fstest.MapFS{
+			"schema.md": &fstest.MapFile{Data: []byte("# ?\n")},
+		},
+		opens: &opens,
+	}
+	cache := lint.NewRunCache()
+	r := &Rule{Schema: "schema.md", Sources: []SchemaSource{{File: "schema.md"}}}
+
+	for _, name := range []string{"a.md", "b.md", "c.md"} {
+		f, err := lint.NewFileFromSource(name, []byte("# Title\n"), true)
+		require.NoError(t, err)
+		f.RootDir = "/repo"
+		f.RootFS = fsys
+		f.RunCache = cache
+		diags := r.Check(f)
+		assert.Empty(t, diags, "host file %q should pass a trivial schema", name)
+	}
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&opens),
+		"schema file must be read once across host files sharing a RunCache")
+}
+
+// TestDispatchSingleFileSchema_InvalidateRereadsSchema pins that the
+// cache is not permanent: invalidating the schema's absolute path
+// (the LSP's edit-then-invalidate loop) forces a fresh read on the
+// next lookup instead of serving stale bytes forever.
+func TestDispatchSingleFileSchema_InvalidateRereadsSchema(t *testing.T) {
+	var opens int32
+	fsys := countingFS{
+		FS: fstest.MapFS{
+			"schema.md": &fstest.MapFile{Data: []byte("# ?\n")},
+		},
+		opens: &opens,
+	}
+	cache := lint.NewRunCache()
+	r := &Rule{Schema: "schema.md", Sources: []SchemaSource{{File: "schema.md"}}}
+
+	newHost := func(name string) *lint.File {
+		f, err := lint.NewFileFromSource(name, []byte("# Title\n"), true)
+		require.NoError(t, err)
+		f.RootDir = "/repo"
+		f.RootFS = fsys
+		f.RunCache = cache
+		return f
+	}
+
+	r.Check(newHost("a.md"))
+	require.Equal(t, int32(1), atomic.LoadInt32(&opens))
+
+	cache.Invalidate("/repo/schema.md")
+
+	r.Check(newHost("b.md"))
+	assert.Equal(t, int32(2), atomic.LoadInt32(&opens),
+		"Invalidate must force a fresh schema read on the next lookup")
+}

--- a/internal/rules/requiredstructure/runcache_perf_test.go
+++ b/internal/rules/requiredstructure/runcache_perf_test.go
@@ -90,3 +90,39 @@ func TestDispatchSingleFileSchema_InvalidateRereadsSchema(t *testing.T) {
 	assert.Equal(t, int32(2), atomic.LoadInt32(&opens),
 		"Invalidate must force a fresh schema read on the next lookup")
 }
+
+// TestDispatchSingleFileSchema_MissingSchemaErrorUsesCallersOwnSpelling
+// pins a review-flagged regression: two kinds that reference the same
+// missing schema file via differently-spelled but path-equivalent
+// strings ("docs/proto.md" vs "./docs/proto.md" — both resolve to the
+// same absSchemaCacheKey) share one RunCache slot. The cached error
+// must not embed whichever caller's spelling happened to trigger the
+// build first; each caller's diagnostic must name its own configured
+// schema path.
+func TestDispatchSingleFileSchema_MissingSchemaErrorUsesCallersOwnSpelling(t *testing.T) {
+	fsys := fstest.MapFS{}
+	cache := lint.NewRunCache()
+
+	rA := &Rule{Schema: "docs/proto.md", Sources: []SchemaSource{{File: "docs/proto.md"}}}
+	rB := &Rule{Schema: "./docs/proto.md", Sources: []SchemaSource{{File: "./docs/proto.md"}}}
+
+	newHost := func(name string) *lint.File {
+		f, err := lint.NewFileFromSource(name, []byte("# Title\n"), true)
+		require.NoError(t, err)
+		f.RootDir = "/repo"
+		f.RootFS = fsys
+		f.RunCache = cache
+		return f
+	}
+
+	diagsA := rA.Check(newHost("a.md"))
+	require.Len(t, diagsA, 1)
+	assert.Contains(t, diagsA[0].Message, `"docs/proto.md"`)
+
+	diagsB := rB.Check(newHost("b.md"))
+	require.Len(t, diagsB, 1)
+	assert.Contains(t, diagsB[0].Message, `"./docs/proto.md"`,
+		"error message must reflect this rule's own configured schema "+
+			"spelling, not a cached spelling from a different kind that "+
+			"happens to resolve to the same absolute schema path")
+}

--- a/internal/rules/tableformat/rule.go
+++ b/internal/rules/tableformat/rule.go
@@ -7,8 +7,9 @@ package tableformat
 
 import (
 	"bytes"
+	"cmp"
 	"fmt"
-	"sort"
+	"slices"
 
 	"github.com/jeduden/mdsmith/internal/archetype/gensection"
 	"github.com/jeduden/mdsmith/internal/lint"
@@ -128,12 +129,16 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 	// diagnostics anchor at the offending row. With multiple tables in
 	// one file the two streams interleave by line, so a final sort
 	// puts the combined slice in source order — what fixture tests
-	// and editors expect.
-	sort.SliceStable(diags, func(i, j int) bool {
-		if diags[i].Line != diags[j].Line {
-			return diags[i].Line < diags[j].Line
+	// and editors expect. slices.SortStableFunc sorts the concrete
+	// lint.Diagnostic values directly, unlike sort.SliceStable, which
+	// drives reflect.Swapper under the hood — see
+	// docs/development/high-performance-go.md's "reflect in hot
+	// paths" anti-pattern.
+	slices.SortStableFunc(diags, func(a, b lint.Diagnostic) int {
+		if a.Line != b.Line {
+			return cmp.Compare(a.Line, b.Line)
 		}
-		return diags[i].Column < diags[j].Column
+		return cmp.Compare(a.Column, b.Column)
 	})
 	return diags
 }

--- a/internal/rules/tableformat/structure.go
+++ b/internal/rules/tableformat/structure.go
@@ -14,8 +14,9 @@ package tableformat
 
 import (
 	"bytes"
+	"cmp"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/jeduden/mdsmith/internal/lint"
@@ -64,11 +65,15 @@ func structureDiagnostics(f *lint.File, style, ruleID, ruleName string) []lint.D
 		diags = append(diags, checkColumnCount(f, t, ruleID, ruleName)...)
 		diags = append(diags, checkSurroundingBlanks(f, t, ruleID, ruleName)...)
 	}
-	sort.SliceStable(diags, func(i, j int) bool {
-		if diags[i].Line != diags[j].Line {
-			return diags[i].Line < diags[j].Line
+	// slices.SortStableFunc sorts the concrete lint.Diagnostic values
+	// directly, unlike sort.SliceStable, which drives reflect.Swapper
+	// under the hood — see docs/development/high-performance-go.md's
+	// "reflect in hot paths" anti-pattern.
+	slices.SortStableFunc(diags, func(a, b lint.Diagnostic) int {
+		if a.Line != b.Line {
+			return cmp.Compare(a.Line, b.Line)
 		}
-		return diags[i].Column < diags[j].Column
+		return cmp.Compare(a.Column, b.Column)
 	})
 	return diags
 }


### PR DESCRIPTION
## Summary

A multi-agent audit of the codebase against
`docs/development/high-performance-go.md` found the project already
highly compliant with its own patterns (pre-sized slices, pooled
buffers, package-scope regexes, byte-gated cheap pre-checks). The
handful of genuine violations found were ranked by severity/impact —
weighted toward default-enabled rules and per-invocation hot paths —
and the top 5 are fixed here with red/green TDD and measured
before/after benchmarks where the win was CPU-bound rather than
allocation-bound. Three rounds of xhigh-severity code review then
surfaced and fixed two more instances of the same anti-pattern plus
one real correctness bug introduced by the new cache (see below).

1. **MDS019 (catalog) — redundant AST walk, no cheap gate.**
   `Check` unconditionally ran `gensection.FindMarkerPairs`'
   top-level AST walk three times per file (once via the engine,
   once each in `checkCaseMismatches` and `checkInjection`) even on
   files with no `<?catalog?>` directive at all — the common case,
   since MDS019 is default-enabled. Added a `bytes.Contains`
   pre-check mirroring `include`'s existing gate, and share one
   `FindMarkerPairs` result between the two hint passes. An
   isolated-timer benchmark shows Check's own cost drops ~75%
   (6.4us → 1.6us, p=0.000) on a no-directive file.

2. **`internal/engine` — reflect-based sort on every run's full
   diagnostic set.** `sortDiagnostics` (the final merge sort every
   `Runner.Run`/`RunSource` call performs) used `sort.SliceStable`,
   which drives `reflect.Swapper` internally — the one place in the
   codebase this exact fix (`slices.SortStableFunc`) had not yet been
   applied, unlike five other packages that sort `lint.Diagnostic`
   the same way. A benchmark sorting 2000 diagnostics shows -14.46%
   CPU and -66.67% allocations (p=0.000).

3. **MDS025 (table-format) — same reflect-sort anti-pattern.** Both
   `Check`'s final merge sort and `structureDiagnostics`' own sort
   used `sort.SliceStable`; MDS025 is default-enabled and both run on
   any file containing a `|` character. Switched to
   `slices.SortStableFunc`.

4. **Remaining reflect-based sorts.** Six packages
   (`ambiguousemphasis`, `noinlinehtml`, `propernames`,
   `nounusedlinkdefinitions`, and — found in review —
   `noreferencestyle`, `nospaceincodespans`) still sorted
   diagnostic-adjacent slices via `sort.Slice`/`sort.SliceStable`.
   Completed the fix everywhere it was still missing.

5. **MDS020 (required-structure) — schema re-read + re-parsed per
   host file.** `dispatchSingleFileSchema` read the schema file from
   disk and re-unmarshalled its YAML front matter (to peek at
   `extends:`) on every single host file's `Check` call. For a
   workspace-wide kind, N host files paid for N identical reads of
   the same schema. Added `RunCache.RawSchemaFile`, a new cache slot
   mirroring the existing `FrontMatter`/`ParsedSchema` slots (same
   load-once-per-absPath semantics, same `Invalidate` wiring), and
   routed the read + extends-peek through it. Verified with a
   counting-`fs.FS` test: the schema is now read once across three
   host files sharing a `RunCache`, and a fresh read is forced again
   after `Invalidate`.

Each fix references the specific guideline pattern it applies from
`docs/development/high-performance-go.md` ("gate expensive analyzers
behind a cheap pre-check", "reflect in hot paths", "memoize
per-input computations").

### Review fixes

Three rounds of xhigh-severity review found and fixed, in order:

- A missing coverage case for the new Line-tiebreak branch in
  `ambiguousemphasis`'s sort comparator (Codecov patch-coverage gate).
- Two `sort.Slice` cut-sorters (`noreferencestyle`,
  `nospaceincodespans`) that follow the exact pattern item 4 was
  meant to close out, but were missed in the original sweep.
- A real bug in the new MDS020 cache: `cachedRawSchema` keyed its
  slot only by absolute schema path, but cached an error string
  already formatted with the *first* caller's `schemaPath` spelling.
  Two kinds referencing the same missing schema via differently
  spelled but path-equivalent strings (`docs/proto.md` vs
  `./docs/proto.md`) would then share a cache slot, and the second
  kind's diagnostic would silently report the first kind's spelling.
  Fixed by caching only the raw (already-normalized) read error and
  formatting the caller-facing message at each call site from that
  caller's own argument. Reproduced with a regression test before
  fixing.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite, no regressions)
- [x] `go tool -modfile=tools/go.mod golangci-lint run` on every
      touched package (0 issues)
- [x] `internal/integration` per-rule allocation budget gate
      (`TestPerRuleAllocBudget`) — all rules, including MDS019,
      MDS020, MDS025
- [x] `mdsmith check .` — self-lint passes clean
- [x] New unit/behavioral tests for each fix (red before, green
      after), plus targeted benchmarks with `benchstat` deltas for
      the two CPU-bound fixes (catalog gate, engine sort)
- [x] Three rounds of xhigh-severity code review, all flagged issues
      fixed and re-verified
