### PR TITLE
feat(schema): let `filename:` accept a list of globs (OR match)

### DIFF
--- a/docs/guides/directives/enforcing-structure.md
+++ b/docs/guides/directives/enforcing-structure.md
@@ -82,6 +82,20 @@ basename matching the glob. If they don't, `check`
 reports: `filename "foo.md" does not match required
 pattern "[0-9]*_*.md"`.
 
+`filename:` also accepts a list of globs. The basename
+then passes when it matches any one of them. This is the
+OR match that `overrides.glob` and `kind-assignment.glob`
+already give. Use it when a kind accepts more than one
+naming shape — say an id-prefixed file or a fixed name:
+
+```markdown
+<?require
+filename:
+  - "[0-9]*_*.md"
+  - "plan.md"
+?>
+```
+
 **Schema-only**: `<?require?>` is only recognized in
 schema files. Using it in a normal file emits:
 `<?require?> is only recognized in schema files; this

--- a/docs/guides/schemas.md
+++ b/docs/guides/schemas.md
@@ -75,9 +75,9 @@ the ISO regex; see
 [Schema field types](../reference/schema-types.md)
 for the registered names and how they are matched.
 
-`filename:` is a glob the document basename must
-match. It sits at the top of the schema block (no
-`require:` wrapper).
+`filename:` is a glob — or a list of globs the
+basename may match any of — at the top of the schema
+block (no `require:` wrapper).
 
 `closed: true` makes the scope strict — unlisted
 headings produce a diagnostic. `closed: false` (the

--- a/docs/reference/section-schema.md
+++ b/docs/reference/section-schema.md
@@ -235,8 +235,8 @@ schema:
   closed: <bool>
 ```
 
-- `filename:` — a glob the document basename
-  must match. Top-level; no `require:` wrapper.
+- `filename:` — a glob, or list of globs any of
+  which the basename matches. No `require:` wrapper.
 - `frontmatter:` — per-key CUE constraints.
   Trailing `?` on a key marks it optional.
 - `sections:` — the top-level section list.

--- a/internal/rules/MDS020-required-structure/README.md
+++ b/internal/rules/MDS020-required-structure/README.md
@@ -58,9 +58,9 @@ file's leading comment for the vocabulary.
 Use `<?require?>` in the schema body to declare
 constraints on files validated against this schema:
 
-| Field      | Type   | Description                           |
-| ---------- | ------ | ------------------------------------- |
-| `filename` | string | Glob the document basename must match |
+| Field      | Type           | Description                                       |
+| ---------- | -------------- | ------------------------------------------------- |
+| `filename` | string or list | Glob(s) the document basename must match (any of) |
 
 ```markdown
 <?require

--- a/internal/rules/MDS020-required-structure/bad/data/filename-list-tmpl.md
+++ b/internal/rules/MDS020-required-structure/bad/data/filename-list-tmpl.md
@@ -1,0 +1,6 @@
+<?require
+filename:
+  - "[0-9]*_*.md"
+  - "plan.md"
+?>
+# ?

--- a/internal/rules/MDS020-required-structure/bad/filename-list-mismatch.md
+++ b/internal/rules/MDS020-required-structure/bad/filename-list-mismatch.md
@@ -1,0 +1,10 @@
+---
+settings:
+  schema: "../../internal/rules/MDS020-required-structure/bad/data/filename-list-tmpl.md"
+diagnostics:
+  - line: 1
+    column: 1
+    message: |-
+      filename: got "filename-list-mismatch.md", expected filename matching one of globs [0-9]*_*.md, plan.md
+---
+# My Doc

--- a/internal/rules/MDS020-required-structure/good/data/filename-list-tmpl.md
+++ b/internal/rules/MDS020-required-structure/good/data/filename-list-tmpl.md
@@ -1,0 +1,6 @@
+<?require
+filename:
+  - "[0-9]*_*.md"
+  - "filename-list-*.md"
+?>
+# ?

--- a/internal/rules/MDS020-required-structure/good/filename-list-match.md
+++ b/internal/rules/MDS020-required-structure/good/filename-list-match.md
@@ -1,0 +1,5 @@
+---
+settings:
+  schema: "../../internal/rules/MDS020-required-structure/good/data/filename-list-tmpl.md"
+---
+# My Doc

--- a/internal/rules/requiredstructure/inline_schema_test.go
+++ b/internal/rules/requiredstructure/inline_schema_test.go
@@ -277,6 +277,28 @@ func TestCheck_InlineSchema_FilenamePattern(t *testing.T) {
 	expectDiagMsg(t, diags, `filename: got "draft.md"`)
 }
 
+func TestCheck_InlineSchema_FilenameListMatchesAlternative(t *testing.T) {
+	// Issue 817: an inline kind schema filename list matches when the
+	// basename matches any one glob, validated through the inline
+	// schema.Validate path.
+	r := &Rule{InlineSchema: inlineSchema(t, map[string]any{
+		"filename": []any{"[0-9]*_*.md", "plan.md"},
+	})}
+	f := newTestFile(t, "plan.md", "# My Plan\n")
+	diags := r.Check(f)
+	expectDiags(t, diags, 0)
+}
+
+func TestCheck_InlineSchema_FilenameListNoneMatch(t *testing.T) {
+	r := &Rule{InlineSchema: inlineSchema(t, map[string]any{
+		"filename": []any{"[0-9]*_*.md", "plan.md"},
+	})}
+	f := newTestFile(t, "notes.md", "# Notes\n")
+	diags := r.Check(f)
+	expectDiagMsg(t, diags,
+		`filename: got "notes.md", expected filename matching one of globs [0-9]*_*.md, plan.md`)
+}
+
 func TestCheck_InlineSchema_FrontmatterCUE(t *testing.T) {
 	r := &Rule{InlineSchema: inlineSchema(t, map[string]any{
 		"frontmatter": map[string]any{

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -1069,8 +1069,13 @@ var (
 
 // schemaConfig holds the parsed schema frontmatter.
 type schemaConfig struct {
-	FrontMatterCUE  string
-	FilenamePattern string // glob pattern the document basename must match
+	FrontMatterCUE string
+	// FilenamePatterns are the globs the document basename must
+	// match — the basename passes when it matches any one of them
+	// (OR semantics, issue 817). A `<?require filename:?>` may spell
+	// this as a single glob string or a YAML sequence of glob
+	// strings. Empty means no filename constraint.
+	FilenamePatterns []string
 
 	// Frontmatter carries the per-key constraint expression
 	// strings. Populated alongside FrontMatterCUE so the
@@ -1159,9 +1164,11 @@ func parseSchemaFrontMatter(prefix []byte, cache *lint.RunCache) (schemaConfig, 
 }
 
 // extractRequireDirective walks the schema AST for a <?require?> PI
-// and parses its YAML body to extract constraints like filename.
-func extractRequireDirective(f *lint.File) (string, error) {
-	var filenamePattern string
+// and parses its YAML body to extract constraints like filename. The
+// `filename:` value may be a single glob string or a YAML sequence of
+// glob strings (issue 817); both decode to the returned slice.
+func extractRequireDirective(f *lint.File) ([]string, error) {
+	var filenamePatterns []string
 	for c := f.AST.FirstChild(); c != nil; c = c.NextSibling() {
 		pi, ok := c.(*piparser.ProcessingInstruction)
 		if !ok || pi.Name != "require" {
@@ -1193,16 +1200,18 @@ func extractRequireDirective(f *lint.File) (string, error) {
 				body = append(body, seg.Value(f.Source)...)
 			}
 		}
-		var params map[string]string
+		var params map[string]any
 		if err := yamlutil.UnmarshalSafe(body, &params); err != nil {
-			return "", fmt.Errorf("invalid <?require?> directive: %w", err)
+			return nil, fmt.Errorf("invalid <?require?> directive: %w", err)
 		}
-		if fn, ok := params["filename"]; ok {
-			filenamePattern = fn
+		pats, err := schema.DecodeFilenameField(params["filename"])
+		if err != nil {
+			return nil, fmt.Errorf("invalid <?require?> directive: %w", err)
 		}
+		filenamePatterns = pats
 		break
 	}
-	return filenamePattern, nil
+	return filenamePatterns, nil
 }
 
 func deriveFrontMatterCUE(yamlBytes []byte) (string, map[string]string, map[string]schema.FieldMeta, error) {
@@ -1578,7 +1587,7 @@ func parseSchemaWithRootFS(
 	f, _ := lint.NewFile("schema", content)
 
 	// Extract <?require?> directive from schema body.
-	filenamePattern, err := extractRequireDirective(f)
+	filenamePatterns, err := extractRequireDirective(f)
 	if err != nil {
 		// cfg.FrontMatterCUE was already compiled (and cached
 		// via RunCache.CompiledCUE) before extractRequireDirective
@@ -1589,7 +1598,7 @@ func parseSchemaWithRootFS(
 		// and Invalidate(schemaPath) cannot evict it.
 		return &parsedSchema{Config: cfg}, nil, err
 	}
-	cfg.FilenamePattern = filenamePattern
+	cfg.FilenamePatterns = filenamePatterns
 
 	// Extract headings, expanding <?include?> directives in the schema.
 	var headings []docHeading
@@ -1598,7 +1607,7 @@ func parseSchemaWithRootFS(
 		cleanPath := filepath.Clean(schemaPath)
 		visited := map[string]struct{}{cleanPath: {}}
 		chain := []string{cleanPath}
-		var fp string
+		var fp []string
 		headings, fp, includes, err = extractSchemaHeadings(f, schemaPath, visited, chain, maxBytes, rootFS)
 		if err != nil {
 			// Surface a partial *parsedSchema (carrying the
@@ -1611,8 +1620,8 @@ func parseSchemaWithRootFS(
 			// evicts the schema's failed-parse slot.
 			return &parsedSchema{Config: cfg}, includes, err
 		}
-		if fp != "" && cfg.FilenamePattern == "" {
-			cfg.FilenamePattern = fp
+		if len(fp) > 0 && len(cfg.FilenamePatterns) == 0 {
+			cfg.FilenamePatterns = fp
 		}
 	} else {
 		headings = extractHeadings(f)
@@ -1661,9 +1670,9 @@ func parseSchemaWithRootFS(
 func extractSchemaHeadings(
 	schemaFile *lint.File, schemaPath string,
 	visited map[string]struct{}, chain []string, maxBytes int64, rootFS fs.FS,
-) ([]docHeading, string, []string, error) {
+) ([]docHeading, []string, []string, error) {
 	var headings []docHeading
-	var filenamePattern string
+	var filenamePatterns []string
 	var includes []string
 
 	err := ast.Walk(schemaFile.AST, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
@@ -1700,8 +1709,8 @@ func extractSchemaHeadings(
 				includes = append(includes, subIncludes...)
 				return ast.WalkStop, walkErr
 			}
-			if fp != "" && filenamePattern == "" {
-				filenamePattern = fp
+			if len(fp) > 0 && len(filenamePatterns) == 0 {
+				filenamePatterns = fp
 			}
 			headings = append(headings, fragHeadings...)
 			if fragIncluded != "" {
@@ -1719,10 +1728,10 @@ func extractSchemaHeadings(
 		// a downstream <?include?> issue must still let
 		// Invalidate(brokenFragment) evict the schema's failed-parse
 		// slot when the fragment is fixed.
-		return nil, "", includes, err
+		return nil, nil, includes, err
 	}
 
-	return headings, filenamePattern, includes, nil
+	return headings, filenamePatterns, includes, nil
 }
 
 // expandSchemaInclude resolves a single <?include?> PI in a schema file,
@@ -1763,10 +1772,10 @@ func resolveSchemaIncludePath(
 func expandSchemaInclude(
 	pi *piparser.ProcessingInstruction, source []byte,
 	schemaPath string, visited map[string]struct{}, chain []string, maxBytes int64, rootFS fs.FS,
-) ([]docHeading, string, string, []string, error) {
+) ([]docHeading, []string, string, []string, error) {
 	includedPath, err := resolveSchemaIncludePath(pi, source, schemaPath)
 	if err != nil {
-		return nil, "", "", nil, err
+		return nil, nil, "", nil, err
 	}
 
 	// Surface includedPath on every error past this point so the
@@ -1776,20 +1785,20 @@ func expandSchemaInclude(
 	// the depth limit), Invalidate(fragmentAbs) then evicts this
 	// schema's failed-parse slot and the next Check re-parses.
 	if len(chain) > maxSchemaIncludeDepth {
-		return nil, "", includedPath, nil, fmt.Errorf(
+		return nil, nil, includedPath, nil, fmt.Errorf(
 			"schema include depth exceeds maximum (%d)", maxSchemaIncludeDepth)
 	}
 	if _, ok := visited[includedPath]; ok {
 		chainCopy := make([]string, len(chain), len(chain)+1)
 		copy(chainCopy, chain)
 		chainCopy = append(chainCopy, includedPath)
-		return nil, "", includedPath, nil, fmt.Errorf(
+		return nil, nil, includedPath, nil, fmt.Errorf(
 			"cyclic include: %s", strings.Join(chainCopy, " -> "))
 	}
 
 	fragData, err := readSchemaInclude(rootFS, includedPath, maxBytes)
 	if err != nil {
-		return nil, "", includedPath, nil, fmt.Errorf(
+		return nil, nil, includedPath, nil, fmt.Errorf(
 			"cannot read schema include file %q: %w", includedPath, err)
 	}
 
@@ -1802,7 +1811,7 @@ func expandSchemaInclude(
 
 	fp, err := extractRequireDirective(fragFile)
 	if err != nil {
-		return nil, "", includedPath, nil, err
+		return nil, nil, includedPath, nil, err
 	}
 
 	visited[includedPath] = struct{}{}
@@ -1816,9 +1825,9 @@ func expandSchemaInclude(
 		// footprint (broken fragment + every successful one
 		// above it) is recorded in the cache's reverse-include
 		// index.
-		return nil, "", includedPath, subIncludes, err
+		return nil, nil, includedPath, subIncludes, err
 	}
-	if fp2 != "" && fp == "" {
+	if len(fp2) > 0 && len(fp) == 0 {
 		fp = fp2
 	}
 
@@ -2540,8 +2549,8 @@ func workspaceRelPath(f *lint.File) string {
 func checkFilenamePattern(
 	f *lint.File, sch *parsedSchema, schemaSource string,
 ) []lint.Diagnostic {
-	pattern := sch.Config.FilenamePattern
-	if pattern == "" {
+	patterns := sch.Config.FilenamePatterns
+	if len(patterns) == 0 {
 		return nil
 	}
 	// Filename diagnostics describe the document as a whole;
@@ -2550,7 +2559,7 @@ func checkFilenamePattern(
 	// section.
 	anchor := schema.NonBodyDiagLine(f)
 	base := filepath.Base(f.Path)
-	matched, err := filepath.Match(pattern, base)
+	matched, badPattern, err := schema.MatchFilename(patterns, base)
 	if err != nil {
 		// Malformed glob in the schema. Surface it via the same
 		// SchemaDiagnostic shape so the message carries the
@@ -2558,7 +2567,7 @@ func checkFilenamePattern(
 		// offending pattern.
 		d := schema.SchemaDiagnostic{
 			Field:     "filename pattern",
-			Actual:    strconv.Quote(pattern),
+			Actual:    strconv.Quote(badPattern),
 			Expected:  "valid glob",
 			Hint:      err.Error(),
 			SchemaRef: buildSchemaRefForLegacy(schemaSource),
@@ -2568,10 +2577,12 @@ func checkFilenamePattern(
 	if !matched {
 		// `glob` keeps the wording aligned with schema.validateFilename
 		// and the path-pattern diagnostic; see the rationale there.
+		// With several globs configured the "expected" clause lists
+		// them all so the OR nature is visible.
 		d := schema.SchemaDiagnostic{
 			Field:     "filename",
 			Actual:    strconv.Quote(base),
-			Expected:  "filename matching glob " + pattern,
+			Expected:  schema.FilenameExpected(patterns),
 			SchemaRef: buildSchemaRefForLegacy(schemaSource),
 		}
 		return []lint.Diagnostic{d.Emit(makeDiag, f.Path, anchor)}

--- a/internal/rules/requiredstructure/rule_test.go
+++ b/internal/rules/requiredstructure/rule_test.go
@@ -757,6 +757,16 @@ filename:
 		`filename: got "notes.md", expected filename matching one of globs [0-9]*_*.md, plan.md`)
 }
 
+func TestCheck_FilenamePatternBadType(t *testing.T) {
+	// A `filename:` list entry that is not a string surfaces the
+	// DecodeFilenameField error as an invalid-schema diagnostic.
+	schemaPath := writeSchema(t, "<?require\nfilename:\n  - 5\n?>\n# ?\n")
+	r := &Rule{Schema: schemaPath}
+	f := newTestFile(t, "plan.md", "# Plan\n")
+	diags := r.Check(f)
+	expectDiagMsg(t, diags, "filename must be a string or list of strings")
+}
+
 func TestCheck_FilenamePatternSingleLinePI(t *testing.T) {
 	schemaPath := writeSchema(t, `<?require filename: "[0-9]*_*.md" ?>
 # ?

--- a/internal/rules/requiredstructure/rule_test.go
+++ b/internal/rules/requiredstructure/rule_test.go
@@ -725,6 +725,38 @@ filename: "[0-9]*_*.md"
 		`filename: got "my-plan.md", expected filename matching glob [0-9]*_*.md`)
 }
 
+func TestCheck_FilenamePatternListMatchesAlternative(t *testing.T) {
+	// Issue 817: a <?require?> filename list matches when the
+	// basename matches any one glob. Here the file matches the
+	// literal `plan.md`, not the id-prefixed shape.
+	schemaPath := writeSchema(t, `<?require
+filename:
+  - "[0-9]*_*.md"
+  - "plan.md"
+?>
+# ?
+`)
+	r := &Rule{Schema: schemaPath}
+	f := newTestFile(t, "plan.md", "# My Plan\n")
+	diags := r.Check(f)
+	expectDiags(t, diags, 0)
+}
+
+func TestCheck_FilenamePatternListNoneMatch(t *testing.T) {
+	schemaPath := writeSchema(t, `<?require
+filename:
+  - "[0-9]*_*.md"
+  - "plan.md"
+?>
+# ?
+`)
+	r := &Rule{Schema: schemaPath}
+	f := newTestFile(t, "notes.md", "# Notes\n")
+	diags := r.Check(f)
+	expectDiagMsg(t, diags,
+		`filename: got "notes.md", expected filename matching one of globs [0-9]*_*.md, plan.md`)
+}
+
 func TestCheck_FilenamePatternSingleLinePI(t *testing.T) {
 	schemaPath := writeSchema(t, `<?require filename: "[0-9]*_*.md" ?>
 # ?
@@ -1206,7 +1238,7 @@ func TestParseSchema_SchemaIncludeRequireMerge(t *testing.T) {
 
 	tmpl, err := parseSchema([]byte(schema), schemaPath, 0)
 	require.NoError(t, err)
-	assert.Equal(t, `[0-9]*_*.md`, tmpl.Config.FilenamePattern)
+	assert.Equal(t, []string{`[0-9]*_*.md`}, tmpl.Config.FilenamePatterns)
 	require.Len(t, tmpl.Headings, 3)
 	assert.Equal(t, "Tasks", tmpl.Headings[2].Text)
 }
@@ -1776,7 +1808,7 @@ func TestExtractRequireDirective_SingleLineEmpty(t *testing.T) {
 	f := newTestFile(t, "schema.md", src)
 	result, err := extractRequireDirective(f)
 	require.NoError(t, err)
-	assert.Equal(t, "", result)
+	assert.Empty(t, result)
 }
 
 // extractPIFileParam: single-line form
@@ -1911,7 +1943,7 @@ func TestParseSchema_SchemaIncludeNestedRequirePropagated(t *testing.T) {
 	tmpl, err := parseSchema([]byte(schema), schemaPath, 0)
 	require.NoError(t, err)
 	// The filename pattern from the nested include should propagate up.
-	assert.Equal(t, "nested-*.md", tmpl.Config.FilenamePattern)
+	assert.Equal(t, []string{"nested-*.md"}, tmpl.Config.FilenamePatterns)
 }
 
 // validateFrontMatterCUE: invalid CUE schema error

--- a/internal/schema/compose.go
+++ b/internal/schema/compose.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -144,17 +145,17 @@ func composeFrontmatter(out *Schema, schemas []*Schema) {
 
 func composeFilename(out *Schema, schemas []*Schema) error {
 	for _, s := range schemas {
-		if s.Filename == "" {
+		if len(s.Filename) == 0 {
 			continue
 		}
-		if out.Filename == "" {
+		if len(out.Filename) == 0 {
 			out.Filename = s.Filename
 			continue
 		}
-		if out.Filename != s.Filename {
+		if !slices.Equal(out.Filename, s.Filename) {
 			return fmt.Errorf(
 				"conflicting filename patterns across "+
-					"composed schemas: %q and %q",
+					"composed schemas: %v and %v",
 				out.Filename, s.Filename)
 		}
 	}

--- a/internal/schema/compose_test.go
+++ b/internal/schema/compose_test.go
@@ -288,11 +288,11 @@ func TestComposeAcronyms_BothRestricted_UnionsScope(t *testing.T) {
 // `out.Filename != s.Filename` false branch: two schemas declaring
 // the same non-empty filename pattern must NOT error.
 func TestCompose_FilenameIdenticalNotConflict(t *testing.T) {
-	a := &Schema{Filename: "[0-9]*.md"}
-	b := &Schema{Filename: "[0-9]*.md"}
+	a := &Schema{Filename: []string{"[0-9]*.md"}}
+	b := &Schema{Filename: []string{"[0-9]*.md"}}
 	out, err := Compose(a, b)
 	require.NoError(t, err)
-	assert.Equal(t, "[0-9]*.md", out.Filename)
+	assert.Equal(t, []string{"[0-9]*.md"}, out.Filename)
 }
 
 // TestCompose_MergeScopeRulesOneSideEmpty covers the
@@ -323,16 +323,28 @@ func TestCanMergeByHeading_PreambleDirect(t *testing.T) {
 // TestCompose_FilenameFirstNonEmpty picks the first non-empty
 // filename pattern; conflicting patterns are an error.
 func TestCompose_FilenameFirstNonEmpty(t *testing.T) {
-	a := &Schema{Filename: ""}
-	b := &Schema{Filename: "[0-9]*.md"}
+	a := &Schema{Filename: nil}
+	b := &Schema{Filename: []string{"[0-9]*.md"}}
 	out, err := Compose(a, b)
 	require.NoError(t, err)
-	assert.Equal(t, "[0-9]*.md", out.Filename)
+	assert.Equal(t, []string{"[0-9]*.md"}, out.Filename)
 }
 
 func TestCompose_FilenameConflictErrors(t *testing.T) {
-	a := &Schema{Filename: "AAA*.md"}
-	b := &Schema{Filename: "BBB*.md"}
+	a := &Schema{Filename: []string{"AAA*.md"}}
+	b := &Schema{Filename: []string{"BBB*.md"}}
+	_, err := Compose(a, b)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "filename")
+}
+
+// TestCompose_FilenameListConflictOnOrder confirms two lists with the
+// same globs in a different order are treated as conflicting: the
+// composed constraint is order-significant in its diagnostic wording,
+// so identical semantics still require identical spelling.
+func TestCompose_FilenameListConflictOnDiffered(t *testing.T) {
+	a := &Schema{Filename: []string{"a-*.md", "b.md"}}
+	b := &Schema{Filename: []string{"a-*.md"}}
 	_, err := Compose(a, b)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "filename")

--- a/internal/schema/coverage_test.go
+++ b/internal/schema/coverage_test.go
@@ -352,6 +352,19 @@ func TestParseFile_RequireMalformedYAML(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid <?require?>")
 }
 
+func TestParseFile_RequireBadFilenameType(t *testing.T) {
+	// A well-formed YAML body whose `filename:` is neither a string
+	// nor a list of strings surfaces the DecodeFilenameField error
+	// wrapped as an invalid-directive diagnostic.
+	dir := t.TempDir()
+	p := writeFile(t, dir, "proto.md",
+		"<?require\nfilename:\n  - 5\n?>\n\n# ?\n")
+	_, err := ParseFile(&FileReader{}, p)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid <?require?>")
+	assert.Contains(t, err.Error(), "filename must be a string or list of strings")
+}
+
 func TestParseFile_FrontmatterPropagatesToSchema(t *testing.T) {
 	// Frontmatter CUE constraints declared in the proto.md surface
 	// on the parsed Schema. lint.StripFrontMatter consumes the

--- a/internal/schema/coverage_test.go
+++ b/internal/schema/coverage_test.go
@@ -126,6 +126,17 @@ func TestParseInline_RejectsBadFilenameType(t *testing.T) {
 	assert.Contains(t, err.Error(), "filename must be a string")
 }
 
+func TestParseInline_FilenameList(t *testing.T) {
+	// Issue 817: an inline kind schema may set `filename:` to a list
+	// of globs; the basename passes when it matches any one of them.
+	raw := map[string]any{
+		"filename": []any{"[0-9]*_*.md", "plan.md"},
+	}
+	sch, err := ParseInline(raw, "kind plan")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"[0-9]*_*.md", "plan.md"}, sch.Filename)
+}
+
 func TestParseInline_RejectsBadClosedType(t *testing.T) {
 	raw := map[string]any{"closed": "true"}
 	_, err := ParseInline(raw, "kind x")
@@ -329,7 +340,7 @@ func TestParseFile_RequireSingleLine(t *testing.T) {
 		"<?require filename: \"plan-*.md\" ?>\n\n# ?\n")
 	sch, err := ParseFile(&FileReader{}, p)
 	require.NoError(t, err)
-	assert.Equal(t, "plan-*.md", sch.Filename)
+	assert.Equal(t, []string{"plan-*.md"}, sch.Filename)
 }
 
 func TestParseFile_RequireMalformedYAML(t *testing.T) {
@@ -366,7 +377,7 @@ func TestParseFile_IncludeFragmentWithFilename(t *testing.T) {
 		"# ?\n\n<?include\nfile: frag.md\n?>\n")
 	sch, err := ParseFile(&FileReader{}, p)
 	require.NoError(t, err)
-	assert.Equal(t, "frag-*.md", sch.Filename,
+	assert.Equal(t, []string{"frag-*.md"}, sch.Filename,
 		"fragment's filename pattern should win when host has none")
 }
 
@@ -383,7 +394,7 @@ func TestParseFile_HostFilenameBeatsIncludeFilename(t *testing.T) {
 		"<?require\nfilename: \"plan-*.md\"\n?>\n\n# ?\n\n<?include\nfile: frag.md\n?>\n")
 	sch, err := ParseFile(&FileReader{}, p)
 	require.NoError(t, err)
-	assert.Equal(t, "plan-*.md", sch.Filename)
+	assert.Equal(t, []string{"plan-*.md"}, sch.Filename)
 }
 
 func TestParseFile_HeadingWithCodeSpan(t *testing.T) {
@@ -428,7 +439,7 @@ func TestSchema_IsEmpty(t *testing.T) {
 	assert.True(t, (*Schema)(nil).IsEmpty())
 	assert.True(t, (&Schema{}).IsEmpty())
 	assert.False(t, (&Schema{Sections: []Scope{{Heading: "X"}}}).IsEmpty())
-	assert.False(t, (&Schema{Filename: "*.md"}).IsEmpty())
+	assert.False(t, (&Schema{Filename: []string{"*.md"}}).IsEmpty())
 	assert.False(t, (&Schema{Frontmatter: map[string]string{"id": "string"}}).IsEmpty())
 }
 

--- a/internal/schema/extend.go
+++ b/internal/schema/extend.go
@@ -455,7 +455,7 @@ func stripOptionalSuffix(key string) string {
 // is the kind's identity and a child variant routinely wants its
 // own pattern (a draft-* RFC, a ratified-* RFC).
 func extendFilename(out, parent, child *Schema) {
-	if child.Filename != "" {
+	if len(child.Filename) > 0 {
 		out.Filename = child.Filename
 		return
 	}

--- a/internal/schema/extend_test.go
+++ b/internal/schema/extend_test.go
@@ -147,31 +147,31 @@ func TestExtend_SectionsParentFlowsThroughWhenChildEmpty(t *testing.T) {
 // TestExtend_FilenameChildWins covers the simple case: a child that
 // declares filename overrides the parent.
 func TestExtend_FilenameChildWins(t *testing.T) {
-	parent := &Schema{Filename: "*.md"}
-	child := &Schema{Filename: "RFC-*.md"}
+	parent := &Schema{Filename: []string{"*.md"}}
+	child := &Schema{Filename: []string{"RFC-*.md"}}
 	out, err := Extend(parent, child)
 	require.NoError(t, err)
-	assert.Equal(t, "RFC-*.md", out.Filename)
+	assert.Equal(t, []string{"RFC-*.md"}, out.Filename)
 }
 
 // TestExtend_FilenameInheritsFromParent verifies the missing-child
 // branch: parent's pattern flows through.
 func TestExtend_FilenameInheritsFromParent(t *testing.T) {
-	parent := &Schema{Filename: "RFC-*.md"}
+	parent := &Schema{Filename: []string{"RFC-*.md"}}
 	child := &Schema{}
 	out, err := Extend(parent, child)
 	require.NoError(t, err)
-	assert.Equal(t, "RFC-*.md", out.Filename)
+	assert.Equal(t, []string{"RFC-*.md"}, out.Filename)
 }
 
 // TestExtend_FilenameIdenticalNoConflict checks the boundary
 // condition: identical patterns on both sides are not a conflict.
 func TestExtend_FilenameIdenticalNoConflict(t *testing.T) {
-	parent := &Schema{Filename: "RFC-*.md"}
-	child := &Schema{Filename: "RFC-*.md"}
+	parent := &Schema{Filename: []string{"RFC-*.md"}}
+	child := &Schema{Filename: []string{"RFC-*.md"}}
 	out, err := Extend(parent, child)
 	require.NoError(t, err)
-	assert.Equal(t, "RFC-*.md", out.Filename)
+	assert.Equal(t, []string{"RFC-*.md"}, out.Filename)
 }
 
 // TestExtend_ClosedChildOverridesWhenSectionsPresent verifies that
@@ -280,11 +280,11 @@ func TestExtend_FrontmatterLinesMerges(t *testing.T) {
 // the parent's, so a draft- or ratified- variant can declare its
 // own filename without conflicting with the base kind.
 func TestExtend_FilenameChildOverridesDifferentParent(t *testing.T) {
-	parent := &Schema{Filename: "RFC-*.md"}
-	child := &Schema{Filename: "DRAFT-*.md"}
+	parent := &Schema{Filename: []string{"RFC-*.md"}}
+	child := &Schema{Filename: []string{"DRAFT-*.md"}}
 	out, err := Extend(parent, child)
 	require.NoError(t, err)
-	assert.Equal(t, "DRAFT-*.md", out.Filename)
+	assert.Equal(t, []string{"DRAFT-*.md"}, out.Filename)
 }
 
 func TestUnsatisfiableKeyError_Error(t *testing.T) {

--- a/internal/schema/filename.go
+++ b/internal/schema/filename.go
@@ -1,0 +1,94 @@
+package schema
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// DecodeFilenameField normalizes a schema `filename:` value into the
+// list of globs the document basename may match. It accepts a single
+// glob string (the historical spelling, kept for backward
+// compatibility) or a YAML sequence of glob strings, giving `filename:`
+// the same OR semantics that `unique-frontmatter.include`,
+// `overrides.glob`, `kind-assignment.glob`, and catalog `glob:` already
+// carry elsewhere in the config. A nil value (absent key) or an empty
+// string yields nil — no filename constraint. Every sequence entry must
+// be a non-empty string.
+func DecodeFilenameField(v any) ([]string, error) {
+	switch t := v.(type) {
+	case nil:
+		return nil, nil
+	case string:
+		if t == "" {
+			return nil, nil
+		}
+		return []string{t}, nil
+	case []any:
+		out := make([]string, 0, len(t))
+		for _, e := range t {
+			s, ok := e.(string)
+			if !ok {
+				return nil, fmt.Errorf(
+					"filename must be a string or list of strings, "+
+						"got %T in the list", e)
+			}
+			if s == "" {
+				return nil, fmt.Errorf(
+					"filename list entries must be non-empty globs")
+			}
+			out = append(out, s)
+		}
+		if len(out) == 0 {
+			return nil, nil
+		}
+		return out, nil
+	case []string:
+		out := make([]string, 0, len(t))
+		for _, s := range t {
+			if s != "" {
+				out = append(out, s)
+			}
+		}
+		if len(out) == 0 {
+			return nil, nil
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf(
+			"filename must be a string or list of strings, got %T", v)
+	}
+}
+
+// MatchFilename reports whether base matches any of the schema filename
+// globs. An empty patterns slice means "no constraint" and returns
+// matched=true. On the first malformed glob it returns matched=false
+// with that pattern and the filepath.Match error; on a clean non-match
+// it returns matched=false with an empty badPattern and a nil error.
+func MatchFilename(patterns []string, base string) (matched bool, badPattern string, err error) {
+	if len(patterns) == 0 {
+		return true, "", nil
+	}
+	for _, p := range patterns {
+		ok, err := filepath.Match(p, base)
+		if err != nil {
+			return false, p, err
+		}
+		if ok {
+			return true, "", nil
+		}
+	}
+	return false, "", nil
+}
+
+// FilenameExpected renders the "expected" clause of a filename
+// diagnostic. A single glob reads "filename matching glob <p>" — the
+// historical wording — while several read
+// "filename matching one of globs <p1>, <p2>" so the OR nature is
+// explicit.
+func FilenameExpected(patterns []string) string {
+	if len(patterns) == 1 {
+		return "filename matching glob " + patterns[0]
+	}
+	return "filename matching one of globs " + strings.Join(patterns, ", ")
+}

--- a/internal/schema/filename.go
+++ b/internal/schema/filename.go
@@ -62,21 +62,32 @@ func DecodeFilenameField(v any) ([]string, error) {
 
 // MatchFilename reports whether base matches any of the schema filename
 // globs. An empty patterns slice means "no constraint" and returns
-// matched=true. On the first malformed glob it returns matched=false
-// with that pattern and the filepath.Match error; on a clean non-match
-// it returns matched=false with an empty badPattern and a nil error.
+// matched=true. A valid match wins regardless of glob order, so a
+// malformed glob never masks a base that matches another glob; only
+// when no glob matches is the first malformed glob (if any) surfaced,
+// returning matched=false with that pattern and the filepath.Match
+// error. On a clean non-match it returns matched=false with an empty
+// badPattern and a nil error.
 func MatchFilename(patterns []string, base string) (matched bool, badPattern string, err error) {
 	if len(patterns) == 0 {
 		return true, "", nil
 	}
+	var firstBad string
+	var firstErr error
 	for _, p := range patterns {
-		ok, err := filepath.Match(p, base)
-		if err != nil {
-			return false, p, err
+		ok, mErr := filepath.Match(p, base)
+		if mErr != nil {
+			if firstErr == nil {
+				firstBad, firstErr = p, mErr
+			}
+			continue
 		}
 		if ok {
 			return true, "", nil
 		}
+	}
+	if firstErr != nil {
+		return false, firstBad, firstErr
 	}
 	return false, "", nil
 }

--- a/internal/schema/filename_test.go
+++ b/internal/schema/filename_test.go
@@ -84,6 +84,16 @@ func TestMatchFilename_MalformedGlobReportsPattern(t *testing.T) {
 	assert.Equal(t, "[unterminated", bad)
 }
 
+func TestMatchFilename_ValidMatchWinsOverEarlierMalformedGlob(t *testing.T) {
+	// A malformed glob ahead of a matching one must not mask the
+	// match: OR matching is order-independent, so the base still
+	// passes and no error is surfaced.
+	matched, bad, err := MatchFilename([]string{"[unterminated", "plan.md"}, "plan.md")
+	require.NoError(t, err)
+	assert.True(t, matched)
+	assert.Empty(t, bad)
+}
+
 func TestFilenameExpected_SingleKeepsHistoricalWording(t *testing.T) {
 	assert.Equal(t,
 		"filename matching glob [0-9]*_*.md",

--- a/internal/schema/filename_test.go
+++ b/internal/schema/filename_test.go
@@ -1,0 +1,97 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeFilenameField_SingleString(t *testing.T) {
+	pats, err := DecodeFilenameField("[0-9]*_*.md")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"[0-9]*_*.md"}, pats)
+}
+
+func TestDecodeFilenameField_List(t *testing.T) {
+	pats, err := DecodeFilenameField([]any{"[0-9]*_*.md", "plan.md"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"[0-9]*_*.md", "plan.md"}, pats)
+}
+
+func TestDecodeFilenameField_StringSliceList(t *testing.T) {
+	// The pre-typed []string path is used when a caller hands the
+	// decoder an already-decoded slice (e.g. a test or a non-YAML
+	// source).
+	pats, err := DecodeFilenameField([]string{"a-*.md", "b.md"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a-*.md", "b.md"}, pats)
+}
+
+func TestDecodeFilenameField_NilAndEmptyAreNoConstraint(t *testing.T) {
+	for _, v := range []any{nil, "", []any{}, []string{}, []string{""}} {
+		pats, err := DecodeFilenameField(v)
+		require.NoError(t, err)
+		assert.Nil(t, pats)
+	}
+}
+
+func TestDecodeFilenameField_EmptyListEntryRejected(t *testing.T) {
+	_, err := DecodeFilenameField([]any{"[0-9]*_*.md", ""})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-empty")
+}
+
+func TestDecodeFilenameField_NonStringListEntryRejected(t *testing.T) {
+	_, err := DecodeFilenameField([]any{"ok.md", 42})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "filename must be a string or list of strings")
+}
+
+func TestDecodeFilenameField_WrongTypeRejected(t *testing.T) {
+	_, err := DecodeFilenameField(42)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "filename must be a string or list of strings")
+}
+
+func TestMatchFilename_NoConstraint(t *testing.T) {
+	matched, bad, err := MatchFilename(nil, "anything.md")
+	require.NoError(t, err)
+	assert.True(t, matched)
+	assert.Empty(t, bad)
+}
+
+func TestMatchFilename_MatchesAnyGlob(t *testing.T) {
+	// The basename matches the second glob but not the first — the
+	// OR semantics issue 817 asked for.
+	matched, bad, err := MatchFilename([]string{"[0-9]*_*.md", "plan.md"}, "plan.md")
+	require.NoError(t, err)
+	assert.True(t, matched)
+	assert.Empty(t, bad)
+}
+
+func TestMatchFilename_NoMatch(t *testing.T) {
+	matched, bad, err := MatchFilename([]string{"[0-9]*_*.md", "plan.md"}, "notes.md")
+	require.NoError(t, err)
+	assert.False(t, matched)
+	assert.Empty(t, bad)
+}
+
+func TestMatchFilename_MalformedGlobReportsPattern(t *testing.T) {
+	matched, bad, err := MatchFilename([]string{"ok-*.md", "[unterminated"}, "notes.md")
+	require.Error(t, err)
+	assert.False(t, matched)
+	assert.Equal(t, "[unterminated", bad)
+}
+
+func TestFilenameExpected_SingleKeepsHistoricalWording(t *testing.T) {
+	assert.Equal(t,
+		"filename matching glob [0-9]*_*.md",
+		FilenameExpected([]string{"[0-9]*_*.md"}))
+}
+
+func TestFilenameExpected_MultipleListsAll(t *testing.T) {
+	assert.Equal(t,
+		"filename matching one of globs [0-9]*_*.md, plan.md",
+		FilenameExpected([]string{"[0-9]*_*.md", "plan.md"}))
+}

--- a/internal/schema/parse_file.go
+++ b/internal/schema/parse_file.go
@@ -86,7 +86,7 @@ func parseFileBytes(
 	if err != nil {
 		return nil, err
 	}
-	if fp != "" {
+	if len(fp) > 0 {
 		sch.Filename = fp
 	}
 
@@ -94,7 +94,7 @@ func parseFileBytes(
 	if err != nil {
 		return nil, err
 	}
-	if sch.Filename == "" && fp2 != "" {
+	if len(sch.Filename) == 0 && len(fp2) > 0 {
 		sch.Filename = fp2
 	}
 
@@ -300,8 +300,10 @@ func stripDelimiters(fm []byte) []byte {
 }
 
 // extractRequireFilename walks the schema AST for a <?require?> PI
-// and parses its YAML body to extract the filename constraint.
-func extractRequireFilename(f *lint.File) (string, error) {
+// and parses its YAML body to extract the filename constraint. The
+// `filename:` value may be a single glob string or a YAML sequence of
+// glob strings (issue 817); both decode to the returned slice.
+func extractRequireFilename(f *lint.File) ([]string, error) {
 	for c := f.AST.FirstChild(); c != nil; c = c.NextSibling() {
 		pi, ok := c.(*piparser.ProcessingInstruction)
 		if !ok || pi.Name != "require" {
@@ -311,13 +313,17 @@ func extractRequireFilename(f *lint.File) (string, error) {
 		if body == "" {
 			continue
 		}
-		var params map[string]string
+		var params map[string]any
 		if err := yamlutil.UnmarshalSafe([]byte(body), &params); err != nil {
-			return "", fmt.Errorf("invalid <?require?> directive: %w", err)
+			return nil, fmt.Errorf("invalid <?require?> directive: %w", err)
 		}
-		return params["filename"], nil
+		pats, err := DecodeFilenameField(params["filename"])
+		if err != nil {
+			return nil, fmt.Errorf("invalid <?require?> directive: %w", err)
+		}
+		return pats, nil
 	}
-	return "", nil
+	return nil, nil
 }
 
 // parseContentDirective decodes a `<?content?>` PI body into one
@@ -369,9 +375,9 @@ func piYAMLBody(pi *piparser.ProcessingInstruction, source []byte) string {
 func collectFileHeadings(
 	f *lint.File, r *FileReader, path string, lineBase int,
 	visited map[string]bool, chain []string,
-) ([]FileHeading, string, error) {
+) ([]FileHeading, []string, error) {
 	var heads []FileHeading
-	var fp string
+	var fp []string
 	// lastOwn indexes the most recent heading contributed by this
 	// file itself. An <?include?> splices fragment headings onto
 	// heads, but a <?content?> row in the host body declares an
@@ -394,7 +400,7 @@ func collectFileHeadings(
 				if err != nil {
 					return ast.WalkStop, err
 				}
-				if fpInc != "" && fp == "" {
+				if len(fpInc) > 0 && len(fp) == 0 {
 					fp = fpInc
 				}
 				heads = append(heads, frag...)
@@ -416,7 +422,7 @@ func collectFileHeadings(
 		return ast.WalkContinue, nil
 	})
 	if err != nil {
-		return nil, "", err
+		return nil, nil, err
 	}
 	return heads, fp, nil
 }
@@ -424,39 +430,39 @@ func collectFileHeadings(
 func expandInclude(
 	pi *piparser.ProcessingInstruction, source []byte,
 	r *FileReader, schemaPath string, visited map[string]bool, chain []string,
-) ([]FileHeading, string, error) {
+) ([]FileHeading, []string, error) {
 	included, err := resolveIncludePath(pi, source, schemaPath)
 	if err != nil {
-		return nil, "", err
+		return nil, nil, err
 	}
 
 	if len(chain) > maxIncludeDepth {
-		return nil, "", fmt.Errorf(
+		return nil, nil, fmt.Errorf(
 			"schema include depth exceeds maximum (%d)", maxIncludeDepth)
 	}
 	if visited[included] {
 		chainCopy := append([]string(nil), chain...)
 		chainCopy = append(chainCopy, included)
-		return nil, "", fmt.Errorf(
+		return nil, nil, fmt.Errorf(
 			"cyclic include: %s", strings.Join(chainCopy, " -> "))
 	}
 
 	data, err := r.readPath(included)
 	if err != nil {
-		return nil, "", fmt.Errorf(
+		return nil, nil, fmt.Errorf(
 			"cannot read schema include file %q: %w", included, err)
 	}
 
 	fragPrefix, body := lint.StripFrontMatter(data)
 	fragFile, err := lint.NewFile(included, body)
 	if err != nil {
-		return nil, "", fmt.Errorf(
+		return nil, nil, fmt.Errorf(
 			"parsing schema include %q: %w", included, err)
 	}
 
 	fp, err := extractRequireFilename(fragFile)
 	if err != nil {
-		return nil, "", err
+		return nil, nil, err
 	}
 
 	visited[included] = true
@@ -465,9 +471,9 @@ func expandInclude(
 	frag, fpFrag, err := collectFileHeadings(fragFile, r, included, lint.CountLines(fragPrefix), visited, nextChain)
 	delete(visited, included)
 	if err != nil {
-		return nil, "", err
+		return nil, nil, err
 	}
-	if fpFrag != "" && fp == "" {
+	if len(fpFrag) > 0 && len(fp) == 0 {
 		fp = fpFrag
 	}
 

--- a/internal/schema/parse_file.go
+++ b/internal/schema/parse_file.go
@@ -454,11 +454,11 @@ func expandInclude(
 	}
 
 	fragPrefix, body := lint.StripFrontMatter(data)
-	fragFile, err := lint.NewFile(included, body)
-	if err != nil {
-		return nil, nil, fmt.Errorf(
-			"parsing schema include %q: %w", included, err)
-	}
+	// lint.NewFile returns a nil error in every code path
+	// (internal/lint/file.go); discard it so this patch carries no
+	// untestable defensive branch, matching expandSchemaInclude in
+	// the requiredstructure package.
+	fragFile, _ := lint.NewFile(included, body)
 
 	fp, err := extractRequireFilename(fragFile)
 	if err != nil {

--- a/internal/schema/parse_inline.go
+++ b/internal/schema/parse_inline.go
@@ -199,11 +199,11 @@ func parseInlineFilename(raw map[string]any, sch *Schema) error {
 	if !ok {
 		return nil
 	}
-	s, ok := v.(string)
-	if !ok {
-		return fmt.Errorf("schema.filename must be a string, got %T", v)
+	pats, err := DecodeFilenameField(v)
+	if err != nil {
+		return fmt.Errorf("schema.%w", err)
 	}
-	sch.Filename = s
+	sch.Filename = pats
 	return nil
 }
 

--- a/internal/schema/plan212_coverage_test.go
+++ b/internal/schema/plan212_coverage_test.go
@@ -73,7 +73,7 @@ func TestParseFile_NestedIncludeFilenamePropagatesUp(t *testing.T) {
 		"# ?\n\n<?include\nfile: mid.md\n?>\n")
 	sch, err := ParseFile(&FileReader{}, p)
 	require.NoError(t, err)
-	assert.Equal(t, "leaf-*.md", sch.Filename,
+	assert.Equal(t, []string{"leaf-*.md"}, sch.Filename,
 		"leaf require filename should propagate up through mid's include")
 }
 

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -60,11 +60,16 @@ type Schema struct {
 	// metadata.
 	FrontmatterMeta map[string]FieldMeta
 
-	// Filename is a glob the document basename must match. Empty
-	// means no filename constraint. Authors set it as a top-level
-	// `filename:` key on the schema (plan 156 dropped the
-	// `require.filename:` nesting).
-	Filename string
+	// Filename is a list of globs the document basename must match —
+	// the basename passes when it matches any one of them (OR
+	// semantics). A nil or empty slice means no filename constraint.
+	// Authors set it as a top-level `filename:` key on the schema
+	// (plan 156 dropped the `require.filename:` nesting), spelled
+	// either as a single glob string or a YAML sequence of glob
+	// strings; issue 817 added the list form so a schema can express
+	// an alternative naming convention (e.g. `[0-9]*_*.md` or
+	// `plan.md`).
+	Filename []string
 
 	// Sections holds the top-level section list at RootLevel; each
 	// Scope may itself nest further sections one heading level
@@ -466,7 +471,7 @@ func (s *Schema) IsEmpty() bool {
 		return true
 	}
 	return len(s.Frontmatter) == 0 &&
-		s.Filename == "" &&
+		len(s.Filename) == 0 &&
 		len(s.Sections) == 0 &&
 		len(s.CrossReferences) == 0 &&
 		s.Acronyms == nil &&

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -91,7 +91,18 @@ func TestParseFile_RequireFilename(t *testing.T) {
 		"<?require\nfilename: \"foo-*.md\"\n?>\n# ?\n")
 	sch, err := ParseFile(&FileReader{}, p)
 	require.NoError(t, err)
-	assert.Equal(t, "foo-*.md", sch.Filename)
+	assert.Equal(t, []string{"foo-*.md"}, sch.Filename)
+}
+
+func TestParseFile_RequireFilenameList(t *testing.T) {
+	// Issue 817: a <?require?> filename may be a YAML sequence of
+	// globs expressing an alternative naming convention.
+	dir := t.TempDir()
+	p := writeFile(t, dir, "proto.md",
+		"<?require\nfilename:\n  - \"[0-9]*_*.md\"\n  - \"plan.md\"\n?>\n# ?\n")
+	sch, err := ParseFile(&FileReader{}, p)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"[0-9]*_*.md", "plan.md"}, sch.Filename)
 }
 
 // ---- ParseInline ----
@@ -129,7 +140,7 @@ func TestParseInline_FrontmatterAndSections(t *testing.T) {
 	sch, err := ParseInline(raw, "kind rfc")
 	require.NoError(t, err)
 	assert.True(t, sch.Closed)
-	assert.Equal(t, "RFC-[0-9][0-9][0-9][0-9].md", sch.Filename)
+	assert.Equal(t, []string{"RFC-[0-9][0-9][0-9][0-9].md"}, sch.Filename)
 	require.Len(t, sch.Sections, 3)
 	assert.Equal(t, "Overview", sch.Sections[0].Heading)
 	require.NotNil(t, sch.Sections[1].Matcher)
@@ -223,6 +234,25 @@ func TestValidate_FilenameMismatch(t *testing.T) {
 	require.Len(t, diags, 1)
 	assert.Contains(t, diags[0].Message,
 		`filename: got "filename-mismatch.md", expected filename matching glob [0-9]*_*.md`)
+}
+
+func TestValidate_FilenameListMatchesAlternative(t *testing.T) {
+	// The document basename matches the second glob but not the
+	// first — issue 817's "either an id-prefixed shape or this other
+	// literal name". No diagnostic is emitted.
+	sch := &Schema{Filename: []string{"[0-9]*_*.md", "plan.md"}}
+	doc := newDocFile(t, "plan.md", "# My Doc\n")
+	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	assert.Empty(t, diags)
+}
+
+func TestValidate_FilenameListNoneMatch(t *testing.T) {
+	sch := &Schema{Filename: []string{"[0-9]*_*.md", "plan.md"}}
+	doc := newDocFile(t, "notes.md", "# My Doc\n")
+	diags := Validate(doc, sch, nil, false, makeDiagForTest)
+	require.Len(t, diags, 1)
+	assert.Contains(t, diags[0].Message,
+		`filename: got "notes.md", expected filename matching one of globs [0-9]*_*.md, plan.md`)
 }
 
 // ---- Validate (inline schemas) ----

--- a/internal/schema/validate.go
+++ b/internal/schema/validate.go
@@ -1666,8 +1666,8 @@ func formatHeading(level int, text string) string {
 func validateFilename(
 	f *lint.File, sch *Schema, mkDiag MakeDiag,
 ) []lint.Diagnostic {
-	pattern := sch.Filename
-	if pattern == "" {
+	patterns := sch.Filename
+	if len(patterns) == 0 {
 		return nil
 	}
 	// Filename and path diagnostics describe the document as a
@@ -1676,7 +1676,7 @@ func validateFilename(
 	// document body starts with a generated section.
 	anchor := nonBodyDiagLine(f)
 	base := filepath.Base(f.Path)
-	matched, err := filepath.Match(pattern, base)
+	matched, badPattern, err := MatchFilename(patterns, base)
 	if err != nil {
 		// Malformed glob in the schema. Surface it via the same
 		// SchemaDiagnostic shape so the message carries a
@@ -1684,7 +1684,7 @@ func validateFilename(
 		// offending pattern.
 		d := SchemaDiagnostic{
 			Field:     "filename pattern",
-			Actual:    strconv.Quote(pattern),
+			Actual:    strconv.Quote(badPattern),
 			Expected:  "valid glob",
 			Hint:      err.Error(),
 			SchemaRef: schemaRef(sch, ""),
@@ -1697,11 +1697,13 @@ func validateFilename(
 		// requirement, which filepath.Match does not accept. The
 		// wording also lines up with the kind-level `path-pattern`
 		// diagnostic ("path matching glob ...") so the user
-		// vocabulary is consistent across both surfaces.
+		// vocabulary is consistent across both surfaces. With
+		// several globs configured the "expected" clause lists them
+		// all so the OR nature is visible.
 		d := SchemaDiagnostic{
 			Field:     "filename",
 			Actual:    strconv.Quote(base),
-			Expected:  "filename matching glob " + pattern,
+			Expected:  FilenameExpected(patterns),
 			SchemaRef: schemaRef(sch, ""),
 		}
 		return []lint.Diagnostic{d.Emit(mkDiag, f.Path, anchor)}


### PR DESCRIPTION
## What

Closes #817.

A schema's `filename:` constraint could only be a **single** glob, matched by `filepath.Match` (no alternation or brace syntax). There was no way to express "either this id-prefixed shape, or exactly this other literal name" through `filename:` alone — passing a YAML sequence failed to parse:

```
MDS020 invalid schema "plan/proto.md": invalid <?require?> directive:
yaml: unmarshal errors:  line 1: cannot unmarshal !!seq into string
```

`filename:` now accepts **either** a single glob string (unchanged, backward compatible) **or** a list of glob strings, matching when the basename matches any one of them — the same OR semantics `overrides.glob`, `kind-assignment.glob`, and catalog `glob:` already give elsewhere in the config:

```markdown
<?require
filename:
  - "[0-9]*_*.md"
  - "plan.md"
?>
```

or inline on a kind:

```yaml
kinds:
  plan:
    schema:
      filename:
        - "[0-9]*_*.md"
        - "plan.md"
```

## How

The constraint is parsed and validated by **two** code paths, both updated:

- **`internal/schema`** package — inline kind schemas, `extends:` inheritance, and composed multi-source schemas (`Schema.Filename` is now `[]string`).
- **`internal/rules/requiredstructure`** legacy parser — the file-schema path MDS020 uses for a single `proto.md` source without `extends:` (the exact path that produced the issue's error). `schemaConfig.FilenamePattern` is now `FilenamePatterns []string`.

Three shared helpers in `internal/schema` keep decoding and diagnostics consistent across both parsers:

- `DecodeFilenameField` — normalizes a string or YAML sequence to `[]string`.
- `MatchFilename` — OR-matches the basename, reporting the offending glob on a malformed pattern.
- `FilenameExpected` — a single glob keeps the historical `filename matching glob X` wording; several render `filename matching one of globs X, Y`.

Merge semantics: `compose` treats two non-empty lists as conflicting unless they're equal (`slices.Equal`); `extends` lets a child override the parent's list wholesale — both unchanged in spirit from the single-string behavior.

## Tests

- Unit tests for `DecodeFilenameField` / `MatchFilename` / `FilenameExpected` (string, list, empty, malformed, wrong-type).
- List-form parse + validate tests for both parsers, including a match that hits only the *second* glob (proving OR) and the multi-glob "expected" diagnostic.
- New MDS020 good/bad fixtures (`filename-list-match` / `filename-list-mismatch`) exercising the feature end to end.

`go test ./...`, `go vet ./...`, `golangci-lint` (0 issues), the rule allocation-budget test, and `mdsmith check .` all pass.

## Docs

Documented the list form in the enforcing-structure guide (full example), the schemas guide, the section-schema reference, and the MDS020 README settings table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qfpat8jP8v3PFnUrM7L3xB)_