### PR TITLE
fix(security): remove proxy blind spot from MDS072 guarded HTTP client

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -266,5 +266,5 @@ footer: |
 | 2608091911 | ✅     | haiku  | [Add dedicated unit tests for occurrence and slidevstructure private helpers](plan/2608091911_arch-fix-missing-unit-tests.md)                           |
 | 2608161754 | ✅     | sonnet | [Vendor go-runewidth as a patched fork so post-LUT versions build under tinygo](plan/2608161754_vendor-runewidth-bump-tinygo.md)                        |
 | 2608161914 | 🔲     | haiku  | [Add dedicated unit tests for the 2026-08-16 touched-set tax findings](plan/2608161914_arch-fix-touched-set-unit-tests.md)                              |
-| 2608282011 | 🔲     | sonnet | [Security hardening batch — 2026-08-28](plan/2608282011_security-hardening-batch-2026-08-28.md)                                                         |
+| 2608282011 | ✅     | sonnet | [Security hardening batch — 2026-08-28](plan/2608282011_security-hardening-batch-2026-08-28.md)                                                         |
 <?/catalog?>

--- a/internal/rules/MDS072-external-link-check/README.md
+++ b/internal/rules/MDS072-external-link-check/README.md
@@ -76,6 +76,22 @@ unreachable"` diagnostic. The guard denies the connection rather than
 issuing a false pass. Set `links.external-allow-internal: true` only
 when you deliberately lint an internal site from a trusted network.
 
+**`HTTP_PROXY` / `HTTPS_PROXY` are ignored on the guarded path.**
+When `external-allow-internal` is `false` (the default), the guarded
+transport sets `Proxy: nil` and dials every URL directly. This is a
+deliberate safety measure. With a proxy set, Go's HTTP transport would
+dial the proxy rather than the destination. The SSRF hook fires at
+dial time, so it would see the proxy IP — not the target. A forward
+proxy on a non-restricted IP could then silently forward the request
+to a restricted address that the hook never checks.
+
+Dialing directly means every hop passes through the SSRF hook.
+As a side effect, URLs only reachable through a forward proxy are
+not probed on the guarded path. Set `external-allow-internal: true`
+to use the permissive client, which honors the environment proxy.
+Only do this from a trusted network where internal access is
+intentional.
+
 ## Egress ceiling
 
 `links.external-max-probes` (default 1000) caps the total number of

--- a/internal/rules/externallink/probe_net.go
+++ b/internal/rules/externallink/probe_net.go
@@ -116,11 +116,28 @@ func buildPermissiveClient() *http.Client {
 	return &http.Client{Transport: transport}
 }
 
+// buildGuardedClient constructs the SSRF-blocking HTTP client.
+//
+// Proxy is deliberately set to nil — not http.ProxyFromEnvironment — on this
+// path.  When a proxy function is set, Go's HTTP transport dials the proxy
+// rather than the destination, so the ssrfControl hook fires on the proxy IP
+// at connect time instead of the target IP.  A forward proxy on a
+// non-restricted IP (e.g. a corporate proxy reachable over the public
+// internet) would therefore receive the request and could forward it to a
+// restricted address — an RFC1918 range, a cloud-metadata IP such as
+// 169.254.169.254, or any other range ssrfControl guards — without the hook
+// ever inspecting the final destination.
+//
+// Setting Proxy: nil forces every dial to be a direct connection so
+// ssrfControl always vets the actual destination IP.  As a consequence,
+// URLs that are only reachable through a forward proxy are not probed when
+// external-allow-internal is false; use external-allow-internal: true (which
+// uses permissiveClient with http.ProxyFromEnvironment) for those cases.
 func buildGuardedClient() *http.Client {
 	dialer := &net.Dialer{Control: ssrfControl}
 	transport := &http.Transport{
 		DialContext:     dialer.DialContext,
-		Proxy:           http.ProxyFromEnvironment,
+		Proxy:           nil, // must stay nil; see comment on buildGuardedClient
 		IdleConnTimeout: 90 * time.Second,
 	}
 	return &http.Client{

--- a/internal/rules/externallink/probe_net_test.go
+++ b/internal/rules/externallink/probe_net_test.go
@@ -3,9 +3,12 @@
 package externallink
 
 import (
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/netip"
+	"net/url"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -207,4 +210,79 @@ func TestProbe_AllowInternalBypassesGuard(t *testing.T) {
 	res := probe(srv.URL, time.Second, true)
 	require.NoError(t, res.err)
 	assert.Equal(t, http.StatusOK, res.statusCode)
+}
+
+// TestGuardedClientHasNoProxy verifies that buildGuardedClient returns a
+// transport with Proxy set to nil.
+//
+// Background: when Proxy is http.ProxyFromEnvironment, Go's HTTP transport
+// dials the environment-configured forward proxy rather than the destination.
+// The ssrfControl hook fires at dial time, so it sees the proxy IP — not the
+// target IP.  A forward proxy on a non-restricted IP (e.g. a corporate
+// proxy on a public address) would therefore receive the request and could
+// forward it to a restricted destination (RFC1918, cloud-metadata IPs, etc.)
+// without ssrfControl ever blocking it.
+//
+// Setting Proxy: nil on the guarded transport ensures every dial is a direct
+// connection, so ssrfControl always vets the actual destination.
+func TestGuardedClientHasNoProxy(t *testing.T) {
+	c := buildGuardedClient()
+	tr, ok := c.Transport.(*http.Transport)
+	require.True(t, ok, "guarded transport must be *http.Transport")
+	assert.Nil(t, tr.Proxy,
+		"guarded transport must have Proxy: nil — a non-nil proxy function lets an "+
+			"environment-configured forward proxy bypass ssrfControl by receiving the "+
+			"request before the dialer fires on the actual destination IP")
+}
+
+// TestGuardedClientDoesNotConsultProxy demonstrates that the guarded transport
+// does not invoke a proxy function for restricted-destination requests.  It
+// constructs a client using the same components as buildGuardedClient but with
+// an explicit tracking proxy function injected, showing that a proxy function
+// IS consulted when set (the bypass vector) and then verifies buildGuardedClient
+// has Proxy: nil so no proxy function can ever intercept the request.
+func TestGuardedClientDoesNotConsultProxy(t *testing.T) {
+	// A proxy function that records whether it was called.  Returning a nil
+	// URL means "no proxy" so no actual proxied dial happens; we only care
+	// whether the transport consulted the function at all.
+	var proxyConsulted atomic.Bool
+	trackingProxyFunc := func(_ *http.Request) (*url.URL, error) {
+		proxyConsulted.Store(true)
+		return nil, nil
+	}
+
+	// Build a transport that is structurally identical to the buggy
+	// buildGuardedClient (ssrfControl dialer + Proxy function).
+	dialer := &net.Dialer{Control: ssrfControl}
+	buggyClient := &http.Client{
+		Transport: &http.Transport{
+			DialContext:     dialer.DialContext,
+			Proxy:           trackingProxyFunc, // the blind-spot field
+			IdleConnTimeout: 90 * time.Second,
+		},
+		CheckRedirect: ssrfCheckRedirect,
+	}
+
+	// Make a request to a restricted RFC1918 address.  ssrfControl blocks the
+	// dial, but the transport must have called Proxy() before dialing.
+	_ = doWithClient(buggyClient, http.MethodGet, "http://10.0.0.1/", 500*time.Millisecond)
+
+	// The tracking proxy func was consulted, proving that with Proxy set the
+	// transport can be redirected to a forward proxy before ssrfControl fires.
+	// On a real deployment the proxy function would return the proxy's public
+	// IP, which ssrfControl allows, and the proxy would forward to 10.0.0.1.
+	assert.True(t, proxyConsulted.Load(),
+		"a transport with a non-nil Proxy function consults it before dialing — "+
+			"this is the blind spot: a public-IP proxy receives the request and "+
+			"can forward it to a restricted destination that ssrfControl never sees")
+
+	// The fixed buildGuardedClient has Proxy: nil: the transport never consults
+	// any proxy function, so restricted destinations are always dialed directly
+	// and ssrfControl always vets the actual target IP.
+	fixedClient := buildGuardedClient()
+	tr, ok := fixedClient.Transport.(*http.Transport)
+	require.True(t, ok, "guarded transport must be *http.Transport")
+	assert.Nil(t, tr.Proxy,
+		"guarded transport must have Proxy: nil so no proxy function can intercept "+
+			"restricted-destination requests before ssrfControl fires on the target IP")
 }

--- a/internal/rules/externallink/probe_net_test.go
+++ b/internal/rules/externallink/probe_net_test.go
@@ -3,12 +3,9 @@
 package externallink
 
 import (
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/netip"
-	"net/url"
-	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -233,56 +230,4 @@ func TestGuardedClientHasNoProxy(t *testing.T) {
 		"guarded transport must have Proxy: nil — a non-nil proxy function lets an "+
 			"environment-configured forward proxy bypass ssrfControl by receiving the "+
 			"request before the dialer fires on the actual destination IP")
-}
-
-// TestGuardedClientDoesNotConsultProxy demonstrates that the guarded transport
-// does not invoke a proxy function for restricted-destination requests.  It
-// constructs a client using the same components as buildGuardedClient but with
-// an explicit tracking proxy function injected, showing that a proxy function
-// IS consulted when set (the bypass vector) and then verifies buildGuardedClient
-// has Proxy: nil so no proxy function can ever intercept the request.
-func TestGuardedClientDoesNotConsultProxy(t *testing.T) {
-	// A proxy function that records whether it was called.  Returning a nil
-	// URL means "no proxy" so no actual proxied dial happens; we only care
-	// whether the transport consulted the function at all.
-	var proxyConsulted atomic.Bool
-	trackingProxyFunc := func(_ *http.Request) (*url.URL, error) {
-		proxyConsulted.Store(true)
-		return nil, nil
-	}
-
-	// Build a transport that is structurally identical to the buggy
-	// buildGuardedClient (ssrfControl dialer + Proxy function).
-	dialer := &net.Dialer{Control: ssrfControl}
-	buggyClient := &http.Client{
-		Transport: &http.Transport{
-			DialContext:     dialer.DialContext,
-			Proxy:           trackingProxyFunc, // the blind-spot field
-			IdleConnTimeout: 90 * time.Second,
-		},
-		CheckRedirect: ssrfCheckRedirect,
-	}
-
-	// Make a request to a restricted RFC1918 address.  ssrfControl blocks the
-	// dial, but the transport must have called Proxy() before dialing.
-	_ = doWithClient(buggyClient, http.MethodGet, "http://10.0.0.1/", 500*time.Millisecond)
-
-	// The tracking proxy func was consulted, proving that with Proxy set the
-	// transport can be redirected to a forward proxy before ssrfControl fires.
-	// On a real deployment the proxy function would return the proxy's public
-	// IP, which ssrfControl allows, and the proxy would forward to 10.0.0.1.
-	assert.True(t, proxyConsulted.Load(),
-		"a transport with a non-nil Proxy function consults it before dialing — "+
-			"this is the blind spot: a public-IP proxy receives the request and "+
-			"can forward it to a restricted destination that ssrfControl never sees")
-
-	// The fixed buildGuardedClient has Proxy: nil: the transport never consults
-	// any proxy function, so restricted destinations are always dialed directly
-	// and ssrfControl always vets the actual target IP.
-	fixedClient := buildGuardedClient()
-	tr, ok := fixedClient.Transport.(*http.Transport)
-	require.True(t, ok, "guarded transport must be *http.Transport")
-	assert.Nil(t, tr.Proxy,
-		"guarded transport must have Proxy: nil so no proxy function can intercept "+
-			"restricted-destination requests before ssrfControl fires on the target IP")
 }

--- a/plan/2608282011_security-hardening-batch-2026-08-28.md
+++ b/plan/2608282011_security-hardening-batch-2026-08-28.md
@@ -1,7 +1,7 @@
 ---
 id: 2608282011
 title: "Security hardening batch — 2026-08-28"
-status: "🔲"
+status: "✅"
 summary: >-
   Close the single informational finding from the 2026-08-28 post-audit
   diff review: the MDS072 guarded HTTP client sets Proxy:
@@ -68,12 +68,12 @@ path and documents the caveat.
 
 ## Acceptance Criteria
 
-- [ ] A red-then-green test proves the guarded client no longer forwards
+- [x] A red-then-green test proves the guarded client no longer forwards
       a restricted-destination request through an environment proxy.
-- [ ] `buildGuardedClient` no longer exposes the proxy blind spot on the
+- [x] `buildGuardedClient` no longer exposes the proxy blind spot on the
       default (`external-allow-internal: false`) path, with a comment
       recording the invariant.
-- [ ] `permissiveClient` behavior (opt-in `external-allow-internal:
+- [x] `permissiveClient` behavior (opt-in `external-allow-internal:
       true`) is unchanged.
-- [ ] The MDS072 user docs state the proxy caveat.
-- [ ] `go test ./...` and `mdsmith check .` pass.
+- [x] The MDS072 user docs state the proxy caveat.
+- [x] `go test ./...` and `mdsmith check .` pass.


### PR DESCRIPTION
## What

Closes plan `2608282011` — security hardening batch 2026-08-28.

The MDS072 external-link-check rule's guarded HTTP client previously set
`Proxy: http.ProxyFromEnvironment`. When `HTTP_PROXY` or `HTTPS_PROXY` is set,
Go's transport dials the forward proxy rather than the destination. The
`ssrfControl` dial hook therefore checks the proxy's IP — not the target's. A
forward proxy on a non-restricted IP can then forward the request to an RFC1918
address, cloud-metadata IP (169.254.169.254), or any other address the SSRF
guard was meant to block, without `ssrfControl` ever seeing it.

This fix sets `Proxy: nil` on the guarded transport so every dial is direct and
`ssrfControl` always vets the actual destination.

Preconditions for the vulnerability: MDS072 must be enabled (off by default), a
forward proxy must be configured in the environment, and that proxy must be
willing to forward to restricted ranges. Defense-in-depth, not an exposed
default.

`permissiveClient` (used when `external-allow-internal: true`) is unchanged and
still honors the environment proxy.

## How

- `internal/rules/externallink/probe_net.go`: `Proxy: http.ProxyFromEnvironment`
  → `Proxy: nil` in `buildGuardedClient`, with a doc comment recording the
  invariant so it cannot be silently reintroduced.
- `internal/rules/externallink/probe_net_test.go`: `TestGuardedClientHasNoProxy`
  asserts the transport's `Proxy` field is nil — red against the old code, green
  after the fix.
- `internal/rules/MDS072-external-link-check/README.md`: new "Environment proxy"
  paragraph documenting that the guarded path does not honor the environment proxy
  and why.

Three rounds of xhigh code review were run after implementation; findings about
an always-green supplementary test and misleading comments were addressed by
keeping only the genuine red-then-green structural assertion.

## Test plan

- [x] `TestGuardedClientHasNoProxy` was red against `Proxy: http.ProxyFromEnvironment` and is green with `Proxy: nil`
- [x] `go test ./internal/rules/externallink/...` passes
- [x] `go test ./...` passes (162 packages, all green)
- [x] `mdsmith check .` passes (583 files, 0 failures)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmgwTtmx5b4VF6aEX783wX)_