### PR TITLE
fix(release): pin PyPI wheel Metadata-Version to 2.4

### DIFF
--- a/docs/development/release-channels/pypi.md
+++ b/docs/development/release-channels/pypi.md
@@ -77,3 +77,26 @@ file is not checked in. Hatchling drops it
 otherwise. `artifacts` lists both possible binary
 names. The wheel contains whichever one
 `build-wheels` staged.
+
+### `core-metadata-version = "2.4"`
+
+Pin the wheel's `Metadata-Version` to `2.4`.
+Hatchling's default floats. It emits `2.4` on 1.29
+and 1.31. It emits `2.5` on 1.30 and 1.32. The
+`pypi` job installs hatchling unpinned, so that
+default would leak into the wheel.
+
+The pinned `pypa/gh-action-pypi-publish` bundles a
+`packaging` older than 26.0. Its twine check treats
+`Metadata-Version: 2.5` as invalid. The rejection
+failed the v0.55.0 publish.
+
+`2.4` is deterministic. It is the newest version the
+pinned publisher accepts. It still carries the PEP
+639 `License-Expression` and `License-File` fields.
+A regression guard lives in `TestBuildWheelsLayout`
+in [`buildwheels_test.go`][bw]. Raise the pin only
+with a publisher bump whose `packaging` accepts the
+newer version.
+
+[bw]: ../../../internal/release/buildwheels_test.go

--- a/internal/release/buildwheels_test.go
+++ b/internal/release/buildwheels_test.go
@@ -144,6 +144,20 @@ func assertWheel(t *testing.T, out string, entries []os.DirEntry, c wheelCase) {
 	meta := readZipMember(t, whl, "/WHEEL")
 	assert.Contains(t, meta, c.tagInWheelMetadata, "%s WHEEL metadata", whl)
 	assert.NotContains(t, meta, "py3-none-any", "%s still claims py3-none-any", whl)
+	// Regression guard: the pinned pypa/gh-action-pypi-publish
+	// bundles a `packaging` older than 26.0, whose twine metadata
+	// check rejects `Metadata-Version: 2.5`. Newer hatchling
+	// defaults to 2.5 — and its DEFAULT_METADATA_VERSION flip-flops
+	// across releases — so pyproject.toml pins
+	// `core-metadata-version = "2.4"` under the wheel target: the
+	// newest version that still carries the PEP 639 license fields
+	// yet is accepted by the pinned publisher. Dropping the pin
+	// reddens the whole release at publish time (it took down
+	// v0.55.0). See docs/development/release-channels/pypi.md.
+	distMeta := readZipMember(t, whl, "/METADATA")
+	assert.Contains(t, distMeta, "Metadata-Version: 2.4",
+		"%s: wheel core metadata must pin version 2.4; the pinned "+
+			"PyPI publish action rejects newer metadata versions", whl)
 	assert.Truef(t, zipHasFile(t, whl, "mdsmith/_bin/"+c.binName),
 		"%s: bundled binary mdsmith/_bin/%s missing", whl, c.binName)
 	// Regression guard: PyPI rejects wheels with duplicate local

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -31,4 +31,5 @@
 
         [tool.hatch.build.targets.wheel]
           artifacts = ["mdsmith/_bin/mdsmith", "mdsmith/_bin/mdsmith.exe"]
+          core-metadata-version = "2.4"
           packages = ["mdsmith"]


### PR DESCRIPTION
## Why

The v0.55.0 release run [failed](https://github.com/jeduden/mdsmith/actions/runs/33249655866) in the `pypi` job. `gh-action-pypi-publish` rejected every wheel:

```
Checking python/dist/mdsmith-0.55.0-py3-none-macosx_11_0_arm64.whl:
ERROR  InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

## Root cause

- Newer **hatchling** defaults `Metadata-Version` to `2.5`, and its `DEFAULT_METADATA_VERSION` **flip-flops** across releases (1.29→2.4, 1.30→2.5, 1.31→2.4, 1.32→2.5). The `pypi` job installs hatchling unpinned via `python -m build` (build isolation on), so `requires = ["hatchling"]` resolves the latest.
- The pinned `pypa/gh-action-pypi-publish` bundles a `packaging` **older than 26.0**, whose `twine` metadata check treats `Metadata-Version: 2.5` as invalid. (`packaging` 24.2/25.0 accept 2.3/2.4 and reject 2.5; 26.0+ accept 2.5.)

The wheel metadata is otherwise valid — only the pinned publisher's stale validator rejects it.

## Fix

Pin `core-metadata-version = "2.4"` under `[tool.hatch.build.targets.wheel]` so the emitted version is **deterministic**, independent of hatchling's floating default. `2.4` is the newest version the pinned publisher accepts and still carries the PEP 639 `License-Expression` / `License-File` fields the wheel ships.

## Verification

- Reproduced locally: hatchling 1.32.0 (default 2.5) → with the override, the wheel emits `Metadata-Version: 2.4` with the PEP 639 license fields intact, and `twine check` **PASSES** under `packaging==24.2` (representative of the pinned action's validator).
- Added a regression guard to `TestBuildWheelsLayout` asserting `Metadata-Version: 2.4` in each wheel's `.dist-info/METADATA` — red against the unpinned default, green after the pin.
- `go build ./...`, `go vet`, `go test ./internal/release/...`, and `mdsmith check .` (583 files) all pass.
- Confirmed `mdsmith-release sync-messaging` preserves the new key on its TOML re-emit.

## Follow-up (release retrigger)

The `release` environment is **main-only**, so a working release must be re-dispatched from `main` after this merges — re-dispatching before merge would rebuild the same broken wheels. Raise the pin above `2.4` only alongside a `pypa/gh-action-pypi-publish` bump whose `packaging` accepts the newer version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YLX9qTWfrupsjY8P5BjD1t)_