### PR TITLE
refactor(cmd/mdsmith): extract backlink algorithm into internal/backlinks

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -267,4 +267,6 @@ footer: |
 | 2608161754 | ✅     | sonnet | [Vendor go-runewidth as a patched fork so post-LUT versions build under tinygo](plan/2608161754_vendor-runewidth-bump-tinygo.md)                        |
 | 2608161914 | 🔲     | haiku  | [Add dedicated unit tests for the 2026-08-16 touched-set tax findings](plan/2608161914_arch-fix-touched-set-unit-tests.md)                              |
 | 2608282011 | ✅     | sonnet | [Security hardening batch — 2026-08-28](plan/2608282011_security-hardening-batch-2026-08-28.md)                                                         |
+| 2608301918 | 🔲     | haiku  | [Add dedicated unit tests for the 2026-08-30 touched-set tax findings](plan/2608301918_arch-fix-touched-set-unit-tests-0830.md)                         |
+| 2608301919 | 🔲     | sonnet | [Relocate RunCache out of internal/lint](plan/2608301919_arch-fix-runcache-package-placement.md)                                                        |
 <?/catalog?>

--- a/PLAN.md
+++ b/PLAN.md
@@ -267,6 +267,8 @@ footer: |
 | 2608161754 | ✅     | sonnet | [Vendor go-runewidth as a patched fork so post-LUT versions build under tinygo](plan/2608161754_vendor-runewidth-bump-tinygo.md)                        |
 | 2608161914 | 🔲     | haiku  | [Add dedicated unit tests for the 2026-08-16 touched-set tax findings](plan/2608161914_arch-fix-touched-set-unit-tests.md)                              |
 | 2608282011 | ✅     | sonnet | [Security hardening batch — 2026-08-28](plan/2608282011_security-hardening-batch-2026-08-28.md)                                                         |
+| 2608301343 | 🔲     | sonnet | [Reduce mdsmith.dev homepage clutter and coined words](plan/2608301343_reduce-homepage-clutter.md)                                                      |
 | 2608301918 | 🔲     | haiku  | [Add dedicated unit tests for the 2026-08-30 touched-set tax findings](plan/2608301918_arch-fix-touched-set-unit-tests-0830.md)                         |
 | 2608301919 | 🔲     | sonnet | [Relocate RunCache out of internal/lint](plan/2608301919_arch-fix-runcache-package-placement.md)                                                        |
+| 2609032052 | 🔲     | opus   | [Resolve config from `pyproject.toml` under `[tool.mdsmith]`](plan/2609032052_pyproject-config-source.md)                                               |
 <?/catalog?>

--- a/cmd/mdsmith/backlinks.go
+++ b/cmd/mdsmith/backlinks.go
@@ -7,45 +7,14 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
 	flag "github.com/spf13/pflag"
 
-	"github.com/jeduden/mdsmith/internal/bytelimit"
-	"github.com/jeduden/mdsmith/internal/config"
-	"github.com/jeduden/mdsmith/internal/globpath"
+	"github.com/jeduden/mdsmith/internal/backlinks"
 	"github.com/jeduden/mdsmith/internal/linkgraph"
-	"github.com/jeduden/mdsmith/internal/lint"
 )
-
-// backlinkRecord is one incoming link to the queried target.
-//
-// Kind is set to "wikilink" only when the record came from an
-// Obsidian-style `[[Page]]` link; for ordinary Markdown links Kind
-// stays empty and is omitted from JSON, so the historical
-// {source, line, text, target} shape every existing consumer reads
-// is preserved unchanged.
-//
-// Alias and Embed are only meaningful when Kind == "wikilink":
-//   - Alias is the `|alias` half of `[[Page|alias]]`, empty when
-//     the source had no alias.
-//   - Embed is true when the source used `![[...]]` rather than
-//     `[[...]]`.
-//
-// All three of Kind, Alias, and Embed are omitempty so a JSON
-// document of standard-link records is byte-for-byte the same as
-// before the wikilink fields were added.
-type backlinkRecord struct {
-	Source string `json:"source"`
-	Line   int    `json:"line"`
-	Text   string `json:"text"`
-	Target string `json:"target"`
-	Kind   string `json:"kind,omitempty"`
-	Alias  string `json:"alias,omitempty"`
-	Embed  bool   `json:"embed,omitempty"`
-}
 
 // backlinksOptions bundles the parsed CLI flags for `backlinks`.
 type backlinksOptions struct {
@@ -130,7 +99,7 @@ func runBacklinks(args []string) int {
 	rootDir := rootDirFromConfig(cfgPath)
 	wantTarget := normalizeWorkspacePath(targetPath)
 
-	records, errs := collectBacklinks(
+	records, errs := backlinks.Collect(
 		files, rootDir, wantTarget, targetAnchor,
 		opts.includePatterns, cfg.Ignore, maxBytes, frontMatterEnabled(cfg),
 	)
@@ -225,217 +194,6 @@ func normalizeWorkspacePath(target string) string {
 	return path.Clean(t)
 }
 
-// collectBacklinks walks every source file in files, extracts its
-// outgoing links via linkgraph, and returns one record per link whose
-// resolved workspace-relative target equals wantTarget. When anchor
-// is non-empty, the link's anchor must also match (after slugifying).
-// includePatterns, when non-empty, filters source paths.
-// ignorePatterns are config `ignore:` globs; matched sources are
-// skipped so backlinks output respects the same scope as check/fix.
-//
-// stripFrontMatter must mirror the config's frontMatter setting so
-// reported line numbers match MDS027 / the engine for the same file.
-//
-// Per-file read or parse failures do not abort the walk; instead they
-// are collected and returned so the caller can surface them on stderr
-// alongside whatever results were produced.
-func collectBacklinks(
-	files []string,
-	rootDir, wantTarget, wantAnchor string,
-	includePatterns, ignorePatterns []string,
-	maxBytes int64,
-	stripFrontMatter bool,
-) ([]backlinkRecord, []error) {
-	wantAnchorSlug := ""
-	if wantAnchor != "" {
-		wantAnchorSlug = linkgraph.NormalizeAnchor(wantAnchor)
-	}
-
-	// Build the workspace wikilink index once per collectBacklinks
-	// call so a corpus with N source files × M distinct wikilink
-	// targets does one fs.WalkDir instead of N×M. Both this
-	// command and MDS027 route through linkgraph.WikilinkIndexFor
-	// so the build/cache semantics live in one place.
-	//
-	// When rootDir is empty (e.g. unit-test calls with files in
-	// the current directory and no resolved workspace root),
-	// wikilink resolution is skipped entirely:
-	// extractBacklinksFromSource leaves f.RootFS unset, and
-	// appendWikilinkBacklinks returns early without producing
-	// any wikilink rows. Standard Markdown links still surface.
-	var index *linkgraph.WikilinkIndex
-	if rootDir != "" {
-		index = linkgraph.WikilinkIndexFor(nil, "", lint.OpenRootFS(rootDir))
-	}
-
-	var records []backlinkRecord
-	var errs []error
-	for _, src := range files {
-		srcRel := workspaceRelativePath(src, rootDir)
-		// Self-links count: the contract is "every workspace file
-		// that links to <target>", and a file that links to itself
-		// satisfies that as literally as any other source.
-		if !sourceMatches(srcRel, includePatterns) ||
-			config.IsIgnored(ignorePatterns, srcRel) {
-			continue
-		}
-		rs, err := extractBacklinksFromSource(
-			src, srcRel, rootDir, wantTarget, wantAnchorSlug,
-			maxBytes, stripFrontMatter, index,
-		)
-		if err != nil {
-			errs = append(errs, err)
-			continue
-		}
-		records = append(records, rs...)
-	}
-	sort.SliceStable(records, func(i, j int) bool {
-		if records[i].Source != records[j].Source {
-			return records[i].Source < records[j].Source
-		}
-		return records[i].Line < records[j].Line
-	})
-	return records, errs
-}
-
-// extractBacklinksFromSource reads one source file, parses it, and
-// returns the backlink records (and any read/parse error) for links
-// that resolve to wantTarget. wantAnchorSlug is the already-slugified
-// anchor query, or "" to match any anchor.
-func extractBacklinksFromSource(
-	src, srcRel, rootDir, wantTarget, wantAnchorSlug string,
-	maxBytes int64, stripFrontMatter bool,
-	index *linkgraph.WikilinkIndex,
-) ([]backlinkRecord, error) {
-	data, err := bytelimit.ReadFileLimited(src, maxBytes)
-	if err != nil {
-		return nil, fmt.Errorf("reading %s: %w", srcRel, err)
-	}
-	// Reuse the lint pipeline's front-matter handling so line numbers
-	// in records match what users see in editors. Mirror the config's
-	// frontMatter setting so backlinks stays aligned with MDS027 when
-	// stripping is turned off.
-	//
-	// NewFileFromSource only errors when NewFile errors, and NewFile
-	// never errors — goldmark always returns an AST. The discard keeps
-	// the linter happy without preserving an unreachable branch.
-	f, _ := lint.NewFileFromSource(src, data, stripFrontMatter) //nolint:errcheck
-	// Wikilink resolution needs the workspace root: ResolveWikiLink
-	// walks the fs.FS to find candidates. Standard Markdown link
-	// resolution operates on the source-relative path and never reads
-	// f.RootFS, so this is a wikilink-only requirement.
-	if rootDir != "" {
-		f.SetRootDir(rootDir)
-	}
-	var out []backlinkRecord
-	for _, link := range linkgraph.ExtractLinks(f) {
-		t := link.Target
-		// Skip same-file anchor refs: backlinks only surfaces cross-
-		// file edges. linkgraph guarantees a non-empty Path whenever
-		// LocalAnchor is false.
-		if t.LocalAnchor {
-			continue
-		}
-		resolved := resolveLinkTarget(srcRel, t.Path)
-		if resolved == "" || resolved != wantTarget {
-			continue
-		}
-		if wantAnchorSlug != "" && linkgraph.NormalizeAnchor(t.Anchor) != wantAnchorSlug {
-			continue
-		}
-		out = append(out, backlinkRecord{
-			Source: srcRel,
-			// ExtractLinks returns body-relative lines (rules need
-			// that for the engine's offset-adjustment); the CLI shows
-			// file-relative line numbers, so add f.LineOffset back in.
-			Line:   link.Line + f.LineOffset,
-			Text:   link.Text(f.Source),
-			Target: t.Raw,
-		})
-	}
-	out = appendWikilinkBacklinks(out, f, srcRel, wantTarget, wantAnchorSlug, index)
-	return out, nil
-}
-
-// appendWikilinkBacklinks scans f for Obsidian-style wikilinks whose
-// resolved workspace-relative target matches wantTarget. Resolution
-// uses the same shortest-path algorithm MDS027 applies, sandboxed to
-// the file's root. Wikilinks are extracted unconditionally — the
-// scan is cheap and the user querying backlinks already opted in by
-// running the command.
-//
-// When a prebuilt index is supplied, every wikilink resolves via
-// O(1) map lookups; otherwise resolution falls back to per-call
-// fs.WalkDir, memoized per target within this file.
-func appendWikilinkBacklinks(
-	out []backlinkRecord,
-	f *lint.File,
-	srcRel, wantTarget, wantAnchorSlug string,
-	index *linkgraph.WikilinkIndex,
-) []backlinkRecord {
-	wikilinks := linkgraph.ExtractWikiLinks(f)
-	if len(wikilinks) == 0 {
-		return out
-	}
-	root := f.RootFS
-	if root == nil && index == nil {
-		return out
-	}
-	type resolveResult struct {
-		path string
-		ok   bool
-	}
-	cache := map[string]resolveResult{}
-	for _, wl := range wikilinks {
-		r, cached := cache[wl.Target]
-		if !cached {
-			if index != nil {
-				r.path, r.ok = index.Resolve(wl.Target)
-			} else {
-				r.path, r.ok = linkgraph.ResolveWikiLink(root, srcRel, wl.Target)
-			}
-			cache[wl.Target] = r
-		}
-		if !r.ok || r.path != wantTarget {
-			continue
-		}
-		if wantAnchorSlug != "" && linkgraph.NormalizeAnchor(wl.Anchor) != wantAnchorSlug {
-			continue
-		}
-		// Visible text mirrors what a reader would see: the alias
-		// when one is present; otherwise the target-as-written
-		// (target + "#anchor" if the source carried a fragment).
-		// Using wl.Target alone would drop the anchor portion from
-		// the JSON `text` field for `[[page#Section]]` and break
-		// downstream round-tripping.
-		text := wl.Alias
-		if text == "" {
-			text = wikilinkTargetString(wl)
-		}
-		out = append(out, backlinkRecord{
-			Source: srcRel,
-			Line:   wl.Line + f.LineOffset,
-			Text:   text,
-			Target: wikilinkTargetString(wl),
-			Kind:   "wikilink",
-			Alias:  wl.Alias,
-			Embed:  wl.Embed,
-		})
-	}
-	return out
-}
-
-// wikilinkTargetString renders just the target+anchor of wl as it
-// appeared in the source — the destination half a Markdown link's
-// Target field would carry. Alias and embed prefix are dropped so
-// the field reflects "where does this point", not "how does it look".
-func wikilinkTargetString(wl linkgraph.WikiLink) string {
-	if wl.Anchor == "" {
-		return wl.Target
-	}
-	return wl.Target + "#" + wl.Anchor
-}
-
 // workspaceRelativePath returns p relative to rootDir using forward
 // slashes. When rootDir is empty or filepath.Rel cannot relate the
 // paths, p is returned as-is with separators normalized.
@@ -457,25 +215,6 @@ func workspaceRelativePath(p, rootDir string) string {
 		return fallback
 	}
 	return filepath.ToSlash(rel)
-}
-
-// resolveLinkTarget joins srcRel's directory with the link's path and
-// returns the workspace-relative result. Both inputs use forward
-// slashes. Absolute paths (including Windows drive letters and UNC
-// prefixes) and ones that escape the workspace root return "" so
-// callers treat them as "outside the graph".
-func resolveLinkTarget(srcRel, linkPath string) string {
-	srcRel = strings.ReplaceAll(srcRel, `\`, `/`)
-	linkPath = strings.ReplaceAll(linkPath, `\`, `/`)
-	if isAbsOrDriveOrUNC(srcRel) || isAbsOrDriveOrUNC(linkPath) {
-		return ""
-	}
-	dir := path.Dir(srcRel)
-	cleaned := path.Clean(path.Join(dir, linkPath))
-	if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
-		return ""
-	}
-	return cleaned
 }
 
 // isAbsOrDriveOrUNC reports whether p is absolute under any of the
@@ -508,20 +247,6 @@ func isWorkspaceRelativeTarget(target string) bool {
 	return cleaned != ".." && !strings.HasPrefix(cleaned, "../")
 }
 
-// sourceMatches reports whether src should be considered, given the
-// list of --include globs. An empty list lets every source through.
-func sourceMatches(src string, includePatterns []string) bool {
-	if len(includePatterns) == 0 {
-		return true
-	}
-	for _, pat := range includePatterns {
-		if globpath.Match(pat, src) {
-			return true
-		}
-	}
-	return false
-}
-
 // formatBacklinkTextLine renders one record for the human text
 // format. Standard links use the `[text](target)` shape; wikilinks
 // use the source-form `[[target]]` (or `[[target|alias]]`,
@@ -530,7 +255,7 @@ func sourceMatches(src string, includePatterns []string) bool {
 // emitted only when the source itself carried one — the heuristic
 // "Text != Target means alias" would misclassify `[[page#Section]]`
 // because Target ("page#Section") differs from Text ("page").
-func formatBacklinkTextLine(r backlinkRecord) string {
+func formatBacklinkTextLine(r backlinks.Record) string {
 	if r.Kind == "wikilink" {
 		prefix := ""
 		if r.Embed {
@@ -548,7 +273,7 @@ func formatBacklinkTextLine(r backlinkRecord) string {
 // emitBacklinks writes records to w using format. limit caps the
 // output; 0 means no cap. Exit code: 0 when records were emitted,
 // 1 when none were found, 2 on write error.
-func emitBacklinks(w io.Writer, records []backlinkRecord, format string, limit int) int {
+func emitBacklinks(w io.Writer, records []backlinks.Record, format string, limit int) int {
 	if limit > 0 && len(records) > limit {
 		records = records[:limit]
 	}
@@ -558,7 +283,7 @@ func emitBacklinks(w io.Writer, records []backlinkRecord, format string, limit i
 		// downstream tools can `length()` without a nil branch.
 		out := records
 		if out == nil {
-			out = []backlinkRecord{}
+			out = []backlinks.Record{}
 		}
 		enc := json.NewEncoder(w)
 		enc.SetIndent("", "  ")

--- a/cmd/mdsmith/backlinks_unit_test.go
+++ b/cmd/mdsmith/backlinks_unit_test.go
@@ -4,60 +4,23 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/jeduden/mdsmith/internal/backlinks"
 )
-
-func TestResolveLinkTarget(t *testing.T) {
-	cases := []struct {
-		name     string
-		src      string
-		linkPath string
-		want     string
-	}{
-		{"sibling", "docs/index.md", "api.md", "docs/api.md"},
-		{"dot-prefix", "docs/index.md", "./api.md", "docs/api.md"},
-		{"parent dir", "docs/sub/index.md", "../api.md", "docs/api.md"},
-		{"two levels up", "plan/045.md", "../docs/api.md", "docs/api.md"},
-		{"escapes root", "docs/api.md", "../../etc/passwd", ""},
-		{"absolute link", "docs/api.md", "/etc/passwd", ""},
-		{"absolute source", "/abs/docs/api.md", "guide.md", ""},
-		// Windows-style absolutes — path.IsAbs alone misses these.
-		{"drive letter link", "docs/api.md", "C:/Windows/system.md", ""},
-		{"drive letter source", "C:/docs/api.md", "guide.md", ""},
-		{"UNC link", "docs/api.md", "//server/share/file.md", ""},
-		{"UNC source", "//server/share/api.md", "guide.md", ""},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := resolveLinkTarget(tc.src, tc.linkPath)
-			assert.Equal(t, tc.want, got)
-		})
-	}
-}
 
 func TestNormalizeWorkspacePath(t *testing.T) {
 	assert.Equal(t, "docs/api.md", normalizeWorkspacePath("docs/api.md"))
 	assert.Equal(t, "docs/api.md", normalizeWorkspacePath("./docs/api.md"))
 }
 
-func TestSourceMatches(t *testing.T) {
-	assert.True(t, sourceMatches("docs/api.md", nil))
-	assert.True(t, sourceMatches("docs/api.md", []string{"docs/**"}))
-	assert.False(t, sourceMatches("plan/045.md", []string{"docs/**"}))
-	assert.True(t, sourceMatches("plan/045.md", []string{"docs/**", "plan/**"}))
-}
-
 func TestEmitBacklinks_Text(t *testing.T) {
 	var buf bytes.Buffer
-	records := []backlinkRecord{
+	records := []backlinks.Record{
 		{Source: "a.md", Line: 1, Text: "ref", Target: "x.md"},
 		{Source: "b.md", Line: 2, Text: "ref2", Target: "./x.md"},
 	}
@@ -70,12 +33,12 @@ func TestEmitBacklinks_Text(t *testing.T) {
 
 func TestEmitBacklinks_JSON(t *testing.T) {
 	var buf bytes.Buffer
-	records := []backlinkRecord{
+	records := []backlinks.Record{
 		{Source: "a.md", Line: 1, Text: "ref", Target: "x.md"},
 	}
 	code := emitBacklinks(&buf, records, "json", 0)
 	assert.Equal(t, 0, code)
-	var decoded []backlinkRecord
+	var decoded []backlinks.Record
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &decoded))
 	assert.Equal(t, records, decoded)
 }
@@ -90,7 +53,7 @@ func TestEmitBacklinks_JSONEmpty(t *testing.T) {
 }
 
 func TestEmitBacklinks_Limit(t *testing.T) {
-	records := []backlinkRecord{
+	records := []backlinks.Record{
 		{Source: "a.md", Line: 1},
 		{Source: "b.md", Line: 1},
 		{Source: "c.md", Line: 1},
@@ -104,166 +67,8 @@ func TestEmitBacklinks_Limit(t *testing.T) {
 
 func TestEmitBacklinks_UnknownFormat(t *testing.T) {
 	var buf bytes.Buffer
-	code := emitBacklinks(&buf, []backlinkRecord{{Source: "a.md"}}, "yaml", 0)
+	code := emitBacklinks(&buf, []backlinks.Record{{Source: "a.md"}}, "yaml", 0)
 	assert.Equal(t, 2, code)
-}
-
-// setupCollectBacklinksFixture creates a small workspace with three
-// distinct sources linking to docs/api.md so the end-to-end tests can
-// share one filesystem layout.
-func setupCollectBacklinksFixture(t *testing.T) (root string, files []string) {
-	t.Helper()
-	root = t.TempDir()
-	mkdir := func(rel string) {
-		require.NoError(t, os.MkdirAll(filepath.Join(root, rel), 0o755))
-	}
-	write := func(rel, body string) {
-		require.NoError(t, os.WriteFile(filepath.Join(root, rel), []byte(body), 0o644))
-	}
-	mkdir("docs")
-	mkdir("plan")
-	mkdir("docs/sub")
-	write("docs/api.md", "# API\n\n## Authentication\n\n## Endpoints\n")
-	write("docs/index.md", "# Index\n\nSee [API reference](api.md).\n")
-	write("docs/sub/guide.md", "# Guide\n\nUse [api docs](../api.md#authentication).\n")
-	write("plan/045_api-overhaul.md", "# Plan\n\n[api](../docs/api.md)\n")
-	// File that does NOT link to api.md.
-	write("docs/changelog.md", "# Changelog\n\n[plan](../plan/045_api-overhaul.md)\n")
-
-	files = []string{
-		filepath.Join(root, "docs/api.md"),
-		filepath.Join(root, "docs/changelog.md"),
-		filepath.Join(root, "docs/index.md"),
-		filepath.Join(root, "docs/sub/guide.md"),
-		filepath.Join(root, "plan/045_api-overhaul.md"),
-	}
-	return root, files
-}
-
-// TestCollectBacklinks_End2End covers the path/anchor combinations the
-// plan's acceptance criteria call out: three sources, anchor scoping,
-// include filter, limit.
-func TestCollectBacklinks_End2End(t *testing.T) {
-	root, files := setupCollectBacklinksFixture(t)
-
-	t.Run("three sources, no anchor", func(t *testing.T) {
-		got, errs := collectBacklinks(files, root, "docs/api.md", "", nil, nil, 0, true)
-		require.Empty(t, errs)
-		require.Len(t, got, 3)
-		assert.Equal(t, "docs/index.md", got[0].Source)
-		assert.Equal(t, "docs/sub/guide.md", got[1].Source)
-		assert.Equal(t, "plan/045_api-overhaul.md", got[2].Source)
-	})
-
-	t.Run("anchor scopes to one source", func(t *testing.T) {
-		got, errs := collectBacklinks(files, root, "docs/api.md", "authentication", nil, nil, 0, true)
-		require.Empty(t, errs)
-		require.Len(t, got, 1)
-		assert.Equal(t, "docs/sub/guide.md", got[0].Source)
-	})
-
-	t.Run("anchor with no hits returns empty", func(t *testing.T) {
-		got, errs := collectBacklinks(files, root, "docs/api.md", "no-such-section", nil, nil, 0, true)
-		assert.Empty(t, errs)
-		assert.Empty(t, got)
-	})
-
-	t.Run("include filter excludes plan/", func(t *testing.T) {
-		got, errs := collectBacklinks(files, root, "docs/api.md", "", []string{"docs/**"}, nil, 0, true)
-		require.Empty(t, errs)
-		require.Len(t, got, 2)
-		assert.Equal(t, "docs/index.md", got[0].Source)
-		assert.Equal(t, "docs/sub/guide.md", got[1].Source)
-	})
-
-	t.Run("unreadable source surfaces as error", func(t *testing.T) {
-		// A path that does not exist on disk: ReadFileLimited fails;
-		// collectBacklinks captures the error rather than swallowing.
-		bad := filepath.Join(root, "does-not-exist.md")
-		filesWithBad := append([]string{bad}, files...)
-		got, errs := collectBacklinks(filesWithBad, root, "docs/api.md", "", nil, nil, 0, true)
-		// The other files still contribute results.
-		assert.NotEmpty(t, got)
-		require.Len(t, errs, 1)
-		assert.Contains(t, errs[0].Error(), "does-not-exist.md")
-	})
-
-}
-
-func TestCollectBacklinks_LocalAnchorSkipped(t *testing.T) {
-	// Source contains only a same-file anchor link, no cross-file
-	// reference to the target. linkgraph yields a LocalAnchor=true
-	// link; collectBacklinks must skip it without trying to resolve a
-	// path target.
-	root, files := setupCollectBacklinksFixture(t)
-	anchorOnly := filepath.Join(root, "anchor-only.md")
-	require.NoError(t, os.WriteFile(anchorOnly,
-		[]byte("# Intro\n\nJump to [section](#section).\n\n## Section\n"), 0o644))
-	filesWithAnchor := append([]string{anchorOnly}, files...)
-	got, errs := collectBacklinks(filesWithAnchor, root, "docs/api.md", "", nil, nil, 0, true)
-	assert.Empty(t, errs)
-	// Same three matches as before; anchor-only.md contributes nothing.
-	assert.Len(t, got, 3)
-}
-
-func TestCollectBacklinks_IgnorePatternsExclude(t *testing.T) {
-	// `plan/**` ignores the plan/* source that links to api.md;
-	// the other two sources still produce records.
-	root, files := setupCollectBacklinksFixture(t)
-	got, errs := collectBacklinks(
-		files, root, "docs/api.md", "",
-		nil, []string{"plan/**"}, 0, true,
-	)
-	require.Empty(t, errs)
-	require.Len(t, got, 2)
-	for _, r := range got {
-		assert.NotContains(t, r.Source, "plan/")
-	}
-}
-
-// TestCollectBacklinks_SelfLink confirms self-references count as
-// incoming edges. The contract is "every workspace file that links
-// to <target>" — a file that links to itself satisfies that as
-// literally as any other source.
-func TestCollectBacklinks_SelfLink(t *testing.T) {
-	root := t.TempDir()
-	require.NoError(t, os.MkdirAll(filepath.Join(root, "docs"), 0o755))
-	// docs/api.md links to itself via `api.md`.
-	require.NoError(t, os.WriteFile(filepath.Join(root, "docs", "api.md"),
-		[]byte("# API\n\nSee [back to top](api.md).\n"), 0o644))
-	files := []string{filepath.Join(root, "docs", "api.md")}
-
-	got, errs := collectBacklinks(files, root, "docs/api.md", "", nil, nil, 0, true)
-	require.Empty(t, errs)
-	require.Len(t, got, 1)
-	assert.Equal(t, "docs/api.md", got[0].Source)
-	assert.Equal(t, "api.md", got[0].Target)
-}
-
-// TestCollectBacklinks_FrontMatterStrippingDisabled verifies the
-// stripFrontMatter parameter is honored. When set to false (matching
-// `frontMatter: false` in config), collectBacklinks parses the entire
-// file including its front matter — line numbers stay in raw file
-// coordinates rather than body-relative.
-func TestCollectBacklinks_FrontMatterStrippingDisabled(t *testing.T) {
-	root, files := setupCollectBacklinksFixture(t)
-	fmSrc := filepath.Join(root, "fm-src.md")
-	require.NoError(t, os.WriteFile(fmSrc,
-		[]byte("---\ntitle: x\n---\n# H\n\nSee [api](docs/api.md).\n"), 0o644))
-	filesWithFM := append([]string{fmSrc}, files...)
-	got, errs := collectBacklinks(filesWithFM, root, "docs/api.md", "", nil, nil, 0, false)
-	require.Empty(t, errs)
-	var fmRec *backlinkRecord
-	for i := range got {
-		if got[i].Source == "fm-src.md" {
-			fmRec = &got[i]
-			break
-		}
-	}
-	require.NotNil(t, fmRec)
-	// Front matter spans 3 lines; the link sits on the 6th line.
-	// stripFrontMatter=false → no LineOffset adjustment → 6.
-	assert.Equal(t, 6, fmRec.Line)
 }
 
 func TestValidateIncludePatterns(t *testing.T) {
@@ -283,30 +88,11 @@ func TestWorkspaceRelativePath_EmptyRootDir(t *testing.T) {
 	assert.Equal(t, "docs/api.md", workspaceRelativePath("docs/api.md", ""))
 }
 
-// TestCollectBacklinks_SortStable verifies that two records from the
-// same source file are returned in line order (the secondary key in
-// the SliceStable comparator).
-func TestCollectBacklinks_SortStable(t *testing.T) {
-	root := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(root, "target.md"), []byte("# T\n"), 0o644))
-	// Two links to target.md from the SAME source: line 3 and line 5.
-	body := "# Src\n\nFirst [a](target.md), and\n\nsecond [b](target.md).\n"
-	require.NoError(t, os.WriteFile(filepath.Join(root, "src.md"), []byte(body), 0o644))
-
-	files := []string{filepath.Join(root, "src.md"), filepath.Join(root, "target.md")}
-	got, errs := collectBacklinks(files, root, "target.md", "", nil, nil, 0, true)
-	require.Empty(t, errs)
-	require.Len(t, got, 2)
-	assert.Equal(t, "src.md", got[0].Source)
-	assert.Equal(t, "src.md", got[1].Source)
-	assert.Less(t, got[0].Line, got[1].Line, "same-source records sort by line")
-}
-
 func TestEmitBacklinks_LimitZeroNoCap(t *testing.T) {
 	// limit=0 means "no cap" — every record is emitted.
-	records := make([]backlinkRecord, 5)
+	records := make([]backlinks.Record, 5)
 	for i := range records {
-		records[i] = backlinkRecord{Source: "a.md", Line: i + 1}
+		records[i] = backlinks.Record{Source: "a.md", Line: i + 1}
 	}
 	var buf bytes.Buffer
 	code := emitBacklinks(&buf, records, "text", 0)
@@ -323,117 +109,29 @@ func (failingWriter) Write([]byte) (int, error) {
 }
 
 func TestEmitBacklinks_TextWriteError(t *testing.T) {
-	records := []backlinkRecord{{Source: "a.md", Line: 1, Text: "t", Target: "x.md"}}
+	records := []backlinks.Record{{Source: "a.md", Line: 1, Text: "t", Target: "x.md"}}
 	code := emitBacklinks(failingWriter{}, records, "text", 0)
 	assert.Equal(t, 2, code)
 }
 
 func TestEmitBacklinks_JSONWriteError(t *testing.T) {
-	code := emitBacklinks(failingWriter{}, []backlinkRecord{{Source: "a.md", Line: 1}}, "json", 0)
+	code := emitBacklinks(failingWriter{}, []backlinks.Record{{Source: "a.md", Line: 1}}, "json", 0)
 	assert.Equal(t, 2, code)
 }
 
-func TestCollectBacklinks_Wikilinks(t *testing.T) {
-	root := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(root, "page.md"), []byte("# Page\n\n## Section\n"), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(root, "other.md"),
-		[]byte("# Other\n\nSee [[page]] and [[page|alias]].\n"), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(root, "anchored.md"),
-		[]byte("# Anchored\n\n[[page#Section]]\n"), 0o644))
-	files := []string{
-		filepath.Join(root, "anchored.md"),
-		filepath.Join(root, "other.md"),
-		filepath.Join(root, "page.md"),
-	}
-
-	t.Run("matches both wikilink shapes", func(t *testing.T) {
-		got, errs := collectBacklinks(files, root, "page.md", "", nil, nil, 0, true)
-		require.Empty(t, errs)
-		// Expect three wikilink hits — two on other.md, one on anchored.md.
-		require.Len(t, got, 3)
-		for _, r := range got {
-			assert.Equal(t, "wikilink", r.Kind, "all wikilink hits must carry kind=wikilink")
-		}
-	})
-
-	t.Run("anchor scoping", func(t *testing.T) {
-		got, errs := collectBacklinks(files, root, "page.md", "section", nil, nil, 0, true)
-		require.Empty(t, errs)
-		require.Len(t, got, 1)
-		assert.Equal(t, "anchored.md", got[0].Source)
-		assert.Equal(t, "wikilink", got[0].Kind)
-		assert.Equal(t, "page#Section", got[0].Target)
-		// `text` is the visible link text — for anchor-only wikilinks
-		// the full target-as-written, not the bare stem. Setting
-		// Text=wl.Target alone would drop the `#Section` half and
-		// break JSON round-tripping.
-		assert.Equal(t, "page#Section", got[0].Text)
-	})
-}
-
-func TestAppendWikilinkBacklinks_FallbackToPerCallWalk(t *testing.T) {
-	// The collectBacklinks public path always pairs index with
-	// RootFS; calling appendWikilinkBacklinks directly with a nil
-	// index but a populated RootFS exercises the per-call
-	// fs.WalkDir fallback, which would otherwise rot if the
-	// helper API ever gets reused without the index.
-	root := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(root, "page.md"), []byte("# P\n"), 0o644))
-	srcPath := filepath.Join(root, "src.md")
-	require.NoError(t, os.WriteFile(srcPath, []byte("# S\n\n[[page]]\n"), 0o644))
-	data, err := os.ReadFile(srcPath)
-	require.NoError(t, err)
-	f, err := lint.NewFileFromSource(srcPath, data, true)
-	require.NoError(t, err)
-	f.RootFS = os.DirFS(root)
-	got := appendWikilinkBacklinks(nil, f, "src.md", "page.md", "", nil)
-	require.Len(t, got, 1)
-	// Target on a wikilink record is the source-form `[[target]]`,
-	// not the resolved filename; resolution matches "page" against
-	// "page.md" but the record carries the bare stem.
-	assert.Equal(t, "page", got[0].Target)
-}
-
-func TestAppendWikilinkBacklinks_NoRootFS(t *testing.T) {
-	// extractBacklinksFromSource leaves f.RootFS nil whenever
-	// rootDir == "" — appendWikilinkBacklinks then has no workspace
-	// to walk and must return the input slice untouched.
-	root := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(root, "src.md"),
-		[]byte("# S\n\n[[page]]\n"), 0o644))
-	files := []string{filepath.Join(root, "src.md")}
-	got, errs := collectBacklinks(files, "", "page.md", "", nil, nil, 0, true)
-	require.Empty(t, errs)
-	assert.Empty(t, got)
-}
-
-func TestAppendWikilinkBacklinks_UnrelatedTargetSkipped(t *testing.T) {
-	// A wikilink that resolves to a different file than wantTarget
-	// exercises the `r.path != wantTarget` continue branch.
-	root := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(root, "other.md"),
-		[]byte("# Other\n"), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(root, "src.md"),
-		[]byte("# S\n\n[[other]]\n"), 0o644))
-	files := []string{filepath.Join(root, "src.md")}
-	got, errs := collectBacklinks(files, root, "page.md", "", nil, nil, 0, true)
-	require.Empty(t, errs)
-	assert.Empty(t, got)
-}
-
 func TestFormatBacklinkTextLine_Wikilink(t *testing.T) {
-	bare := backlinkRecord{
+	bare := backlinks.Record{
 		Source: "from.md", Line: 4, Text: "page", Target: "page", Kind: "wikilink",
 	}
 	assert.Equal(t, "from.md:4: [[page]]", formatBacklinkTextLine(bare))
 
-	alias := backlinkRecord{
+	alias := backlinks.Record{
 		Source: "from.md", Line: 4, Text: "Display", Target: "page",
 		Kind: "wikilink", Alias: "Display",
 	}
 	assert.Equal(t, "from.md:4: [[page|Display]]", formatBacklinkTextLine(alias))
 
-	anchorNoAlias := backlinkRecord{
+	anchorNoAlias := backlinks.Record{
 		Source: "from.md", Line: 4, Text: "page",
 		Target: "page#Section", Kind: "wikilink",
 	}
@@ -441,13 +139,13 @@ func TestFormatBacklinkTextLine_Wikilink(t *testing.T) {
 	// alias half is empty so the format emits only the target.
 	assert.Equal(t, "from.md:4: [[page#Section]]", formatBacklinkTextLine(anchorNoAlias))
 
-	embed := backlinkRecord{
+	embed := backlinks.Record{
 		Source: "from.md", Line: 4, Text: "img.png",
 		Target: "img.png", Kind: "wikilink", Embed: true,
 	}
 	assert.Equal(t, "from.md:4: ![[img.png]]", formatBacklinkTextLine(embed))
 
-	std := backlinkRecord{
+	std := backlinks.Record{
 		Source: "from.md", Line: 1, Text: "ref", Target: "x.md",
 	}
 	assert.Equal(t, "from.md:1: [ref](x.md)", formatBacklinkTextLine(std))

--- a/docs/development/architecture-audit-archive-2.md
+++ b/docs/development/architecture-audit-archive-2.md
@@ -202,3 +202,80 @@ forbids `cmd/mdsmith` → `internal/lsp`.
 ### nice-to-have (2026-05-19)
 
 `cue/types` not in layering map — [plan/206][206].
+
+## Audit 2026-05-31 (range: 4809097..37488a7)
+
+Plans 200, 201, 202 green. Tax:
+[plan/223][223] (`pkg/mdsmith` private helpers),
+[plan/224][224] (`internal/lint` SRP, now 12 files).
+`linkstyle` helpers — add tests in-place.
+
+[223]: ../../plan/223_arch-fix-mdsmith-helper-tests.md
+
+### nice-to-have (2026-06-02)
+
+`internal/punkt` not in the layering map —
+[plan/225][225]. Separately, [plan/224][224]
+(`internal/lint` SRP) is now implemented:
+`gitignore`, `bytelimit`, and `piparser`
+split into sibling packages.
+
+[225]: ../../plan/225_arch-fix-punkt-layering.md
+
+## Audit 2026-06-07 (range: 37488a7..82583fc)
+
+Plans 203–225 green. Blocker: `Session.CheckSource`
+(public API) had no unit test. Fixed: added
+`pkg/mdsmith/checksource_test.go` with 4 tests.
+Tax: the [tablereadability dedup][2606071930] and
+[include helper test][2606071931] plans.
+
+[2606071930]: ../../plan/2606071930_arch-fix-tablereadability-dup.md
+[2606071931]: ../../plan/2606071931_arch-fix-include-helper-tests.md
+
+## Audit 2026-06-14 (range: 82583fc..aed18aa)
+
+Tax: [build→rules DIP](../../plan/2606141910_arch-fix-build-rules-dip.md),
+[engine wrappers](../../plan/2606141911_arch-fix-engine-deprecated-wrappers.md),
+[secreview tests](../../plan/2606141912_arch-fix-secreview-report-tests.md).
+
+## Audit 2026-06-16 (range: aed18aa..7793b97)
+
+Lazy-parse series (plans 2606141901–2606141904).
+Tax: [new-pkg-docs](../../plan/2606162213_arch-fix-new-pkg-docs.md),
+[helper-tests](../../plan/2606162214_arch-fix-missing-helper-tests.md).
+
+## Audit 2026-06-21 (range: 7793b97..e701b94)
+
+Parity + Layer-0 parse-skip series.
+Symlink containment; engine panic recovery.
+VS Code `kinds` and `rule-doc` commands.
+270 Go/TS sources. No blockers,
+rule-to-rule imports, or DIP violations.
+
+### tax (2026-06-21)
+
+- `internal/engine/runner.go` (1 290 lines) —
+  SRP: 7 concerns. Fixed this cycle: split into
+  `runner_layer0.go`, `runner_cache.go`,
+  `runner_log.go` — [plan/2606211907][2606211907].
+
+- `internal/lint/layer0.go` (1 203 lines) —
+  full Layer-0 block scanner. Fix: split along
+  block-type sub-parsers —
+  [plan/2606211908][2606211908].
+
+- `internal/lsp/server.go` (1 007 lines) —
+  crept back over 1 000 lines. Dispatch-group
+  split — [plan/2606211909][2606211909].
+
+### nice-to-have (2026-06-21)
+
+- `pkg/mdsmith/workspace.go` trivial methods
+  lack "// no test by design" exemptions —
+  [plan/2606211910][2606211910].
+
+[2606211907]: ../../plan/2606211907_arch-fix-runner-srp-split.md
+[2606211908]: ../../plan/2606211908_arch-fix-layer0-split.md
+[2606211909]: ../../plan/2606211909_arch-fix-lsp-server-split.md
+[2606211910]: ../../plan/2606211910_arch-fix-workspace-exemptions.md

--- a/docs/development/architecture-audit-archive.md
+++ b/docs/development/architecture-audit-archive.md
@@ -21,85 +21,11 @@ on to
 It hit the budget again on 2026-08-23; entries
 from 2026-05-13 through 2026-05-19 moved on to
 [the second archive](architecture-audit-archive-2.md)
-as well.
-
-## Audit 2026-05-31 (range: 4809097..37488a7)
-
-Plans 200, 201, 202 green. Tax:
-[plan/223][223] (`pkg/mdsmith` private helpers),
-[plan/224][224] (`internal/lint` SRP, now 12 files).
-`linkstyle` helpers — add tests in-place.
-
-[223]: ../../plan/223_arch-fix-mdsmith-helper-tests.md
-[224]: ../../plan/224_arch-fix-lint-srp.md
-
-### nice-to-have (2026-06-02)
-
-`internal/punkt` not in the layering map —
-[plan/225][225]. Separately, [plan/224][224]
-(`internal/lint` SRP) is now implemented:
-`gitignore`, `bytelimit`, and `piparser`
-split into sibling packages.
-
-[225]: ../../plan/225_arch-fix-punkt-layering.md
-
-## Audit 2026-06-07 (range: 37488a7..82583fc)
-
-Plans 203–225 green. Blocker: `Session.CheckSource`
-(public API) had no unit test. Fixed: added
-`pkg/mdsmith/checksource_test.go` with 4 tests.
-Tax: the [tablereadability dedup][2606071930] and
-[include helper test][2606071931] plans.
-
-[2606071930]: ../../plan/2606071930_arch-fix-tablereadability-dup.md
-[2606071931]: ../../plan/2606071931_arch-fix-include-helper-tests.md
-
-## Audit 2026-06-14 (range: 82583fc..aed18aa)
-
-Tax: [build→rules DIP](../../plan/2606141910_arch-fix-build-rules-dip.md),
-[engine wrappers](../../plan/2606141911_arch-fix-engine-deprecated-wrappers.md),
-[secreview tests](../../plan/2606141912_arch-fix-secreview-report-tests.md).
-
-## Audit 2026-06-16 (range: aed18aa..7793b97)
-
-Lazy-parse series (plans 2606141901–2606141904).
-Tax: [new-pkg-docs](../../plan/2606162213_arch-fix-new-pkg-docs.md),
-[helper-tests](../../plan/2606162214_arch-fix-missing-helper-tests.md).
-
-## Audit 2026-06-21 (range: 7793b97..e701b94)
-
-Parity + Layer-0 parse-skip series.
-Symlink containment; engine panic recovery.
-VS Code `kinds` and `rule-doc` commands.
-270 Go/TS sources. No blockers,
-rule-to-rule imports, or DIP violations.
-
-### tax (2026-06-21)
-
-- `internal/engine/runner.go` (1 290 lines) —
-  SRP: 7 concerns. Fixed this cycle: split into
-  `runner_layer0.go`, `runner_cache.go`,
-  `runner_log.go` — [plan/2606211907][2606211907].
-
-- `internal/lint/layer0.go` (1 203 lines) —
-  full Layer-0 block scanner. Fix: split along
-  block-type sub-parsers —
-  [plan/2606211908][2606211908].
-
-- `internal/lsp/server.go` (1 007 lines) —
-  crept back over 1 000 lines. Dispatch-group
-  split — [plan/2606211909][2606211909].
-
-### nice-to-have (2026-06-21)
-
-- `pkg/mdsmith/workspace.go` trivial methods
-  lack "// no test by design" exemptions —
-  [plan/2606211910][2606211910].
-
-[2606211907]: ../../plan/2606211907_arch-fix-runner-srp-split.md
-[2606211908]: ../../plan/2606211908_arch-fix-layer0-split.md
-[2606211909]: ../../plan/2606211909_arch-fix-lsp-server-split.md
-[2606211910]: ../../plan/2606211910_arch-fix-workspace-exemptions.md
+as well. It hit the budget again on 2026-08-30;
+entries from 2026-05-31 through 2026-06-21 moved
+on to
+[the second archive](architecture-audit-archive-2.md)
+too.
 
 ## Audit 2026-06-23 (range: e701b94..1599c9f)
 
@@ -271,3 +197,88 @@ None.
 
 [tests]: architecture/tests.md
 [go]: architecture/go.md
+
+## Audit 2026-08-09 (range: 6680ff5..2ab4b29)
+
+100 commits, 148 files touched (92 Go files).
+
+New packages this cycle:
+
+- `internal/foreignregion` — foreign managed-region
+  protection for check/fix.
+- `internal/convention` — extracted convention model.
+
+New opt-in rules this cycle:
+
+- `internal/rules/occurrence` (MDS060).
+- `internal/rules/slidevstructure` (MDS073).
+
+No rule-to-rule imports. No reverse-layer imports. No
+Liskov breaks. `cmd/mdsmith/main.go` (709 lines) stayed well
+under the ~1000-line threshold, as did
+`internal/lsp/server.go`/`symbols.go` (554/511 lines).
+
+Clean surfaces, verified:
+
+- `internal/mdpath` consolidation: `IsMarkdownPath` grew into
+  a single source of truth (`Extensions`, `FileGlobs`,
+  `RecursiveGlobs`, `HasMarkdownExt`) now consumed by
+  `internal/lsp`, `internal/config`, and the merge-driver
+  include set — SRP fix per go.md's "package answers one
+  question." Every function has an exact-name test.
+- `cmd/mdsmith/init.go` split: extracted from `main.go` with
+  full dedicated-test coverage — 39 `Test*` functions cover
+  all 13 functions, including error paths.
+- `internal/rules/crossfilereferenceintegrity`'s
+  double-checked-locking memoization
+  (`cachedGlobSettingsErr`) is pinned by dedicated tests
+  following the `TestReceiver_Foo` naming convention.
+
+### blockers (2026-08-09)
+
+- `MDS073` is claimed by two unrelated, independently
+  registered diagnostics. `internal/rules/slidevstructure/rule.go:52`
+  returns `"MDS073"` for the Slidev slide-structure rule
+  (registered in `internal/rules/all/all.go`, documented at
+  `internal/rules/MDS073-slide-structure/README.md`).
+  `internal/foreignregion/scan.go:25` independently defines
+  `RuleID = "MDS073"` for the malformed-marker-pair
+  diagnostic (wired into `internal/engine/runner.go` and
+  `internal/fix/fix.go`, documented at
+  `docs/reference/foreign-regions.md:76`). Both landed the
+  same day (2026-07-19) — slide-structure was renumbered
+  `MDS072 -> MDS073` in `7e4925a` while the foreign-region
+  feature independently claimed `MDS073` in parallel commits
+  — an undetected rebase/merge collision.
+  [cross-system.md][cross] treats rule IDs as part of the
+  public `.mdsmith.yml`/CLI/docs contract; no test in
+  `internal/integration/` or `internal/rule/` enforces
+  uniqueness across `rule.All()` plus out-of-band IDs like
+  foreign-region's. Fixed by renumbering the foreign-region
+  diagnostic to the next free ID and adding a uniqueness
+  contract test — [plan/2608091910][2608091910].
+
+### tax (2026-08-09)
+
+- `internal/rules/occurrence/rule.go` has 18 non-trivial
+  private helpers with no dedicated unit test by name
+  (`countCombinedInRange`, `searchText`, `applyScope`, …).
+  All are covered indirectly by 47 behavior-level
+  `TestCheck_*`/`TestApplySettings_*` cases, but
+  [tests.md][tests] requires a test by the function's own
+  name, and the pre-existing sibling rule
+  `paragraphstructure` follows that convention for every
+  helper — [plan/2608091911][2608091911].
+- `internal/rules/slidevstructure/rule.go` has 11
+  non-trivial private helpers (`checkSlide`, `slideAnchor`,
+  `nearest`, …) in the same shape — covered behaviorally by
+  35 `Test*` cases but not by name —
+  [plan/2608091911][2608091911].
+
+[cross]: architecture/cross-system.md
+[2608091910]: ../../plan/2608091910_arch-fix-mds073-collision.md
+[2608091911]: ../../plan/2608091911_arch-fix-missing-unit-tests.md
+
+### nice-to-have (2026-08-09)
+
+None found this cycle beyond the tax items above.

--- a/docs/development/architecture-audit.md
+++ b/docs/development/architecture-audit.md
@@ -6,7 +6,7 @@ summary: >-
   solid-architecture skill (audit mode)
   appends here; blockers are also filed as
   plans.
-audit-from: b706d7618cca472108b80ccd837877fad80230b3
+audit-from: 0ca0d2f7c95ab53e3e9ed8851150af98b95088fb
 ---
 # Architecture audit log
 
@@ -16,6 +16,120 @@ The oldest entries have moved to the
 [archive shards](architecture-audit-archive.md) to stay
 under the file-length budget; every finding there is
 resolved.
+
+## Audit 2026-08-30 (range: b706d76..0ca0d2f)
+
+59 commits, ~130 files touched (~125 Go files, no
+TypeScript). New packages this cycle:
+
+- `internal/linkgraph` — link/wikilink target parsing and
+  resolution, split out of the rules that used to inline it.
+- `internal/schema` — a one-question-per-file split (compose,
+  extend, filename, parse_file, parse_inline, validate) with
+  no reverse-layer imports.
+- `internal/gitattributes` and `internal/directivefiles` —
+  the two other packages the 2026-08-23 `internal/githooks`
+  SRP split ([plan/2608021916][2608021916]) produced. That
+  plan is now fully merged (PR #815); its "picked up as this
+  cycle's fix" note from 2026-08-23 is closed.
+
+Rule-ID collisions hit this project once before
+([plan/2608091910][2608091910]). Checked for a repeat:
+
+- `internal/foreignregion` claims `MDS074`.
+- `internal/rules/overrepetition` claims `MDS075`.
+- Checked against `internal/rules/all/all.go` and
+  `internal/integration/testdata/rule_walk_audit.json`.
+- No overlap. No repeat this cycle.
+
+Clean surfaces, verified:
+
+- No rule-to-rule imports. No reverse-layer imports. No
+  Liskov breaks.
+- `internal/linkgraph`, `internal/schema`,
+  `internal/gitattributes`, `internal/directivefiles`: each
+  answers one question, each has dedicated tests, none
+  imports `internal/rules/...`.
+- `cmd/mdsmith/discover.go` is an exemplary thin shim over
+  `internal/directivefiles.DiscoverFilesForInstall` — no
+  domain logic in the handler.
+- `internal/rules/catalog/rule.go` and
+  `internal/rules/requiredstructure/rule.go`'s changes this
+  cycle are perf-only (`RunCache.RawSchemaFile`, MDS019
+  pre-check gating); no new imports, both ship dedicated
+  tests.
+
+### blockers (2026-08-30)
+
+None.
+
+### tax (2026-08-30)
+
+- `cmd/mdsmith/backlinks.go` had ~430 of 585 lines carrying
+  the backlink target-matching algorithm — link/wikilink
+  resolution, workspace-relative path math — inside the CLI
+  package. [go.md][go] §"Clean wiring in `cmd/mdsmith`":
+  "Domain logic ... belongs in `pkg/mdsmith`,
+  `internal/engine`, or their dependencies." This was the
+  newest and most self-contained instance of the pattern
+  (`mergedriver.go` carries some of the same weight but is
+  out of this cycle's touched set). Fixed directly (not
+  filed as a plan): extracted `Record`, `Collect`, and every
+  private helper the matching algorithm needs into a new
+  `internal/backlinks` package; `cmd/mdsmith/backlinks.go`
+  now only parses flags, validates arguments, calls
+  `backlinks.Collect`, and formats output —
+  `runBacklinks` stays a thin dispatcher. `workspaceRelativePath`
+  and `isAbsOrDriveOrUNC` stayed in `cmd/mdsmith` (shared by
+  `deps.go` and `rename.go` too, not backlinks-specific); the
+  new package carries its own small private duplicates for
+  the two pure predicates it needs
+  (`relPath`/`isAbsOrDriveOrUNC`) rather than importing
+  `cmd/mdsmith`, which would invert the dependency direction.
+  `go build ./...`, `go test ./...`, and
+  `go tool golangci-lint run` are green; behavior is
+  unchanged (existing unit and e2e tests moved/kept
+  untouched).
+- `internal/mdtext/wordfreq.go`'s `WordFrequencyInto` and
+  three helpers in `internal/directivefiles/directivefiles.go`
+  (`openingFence`, `isClosingFence`, `isIndentedCodeBlock`)
+  have no dedicated unit test by name, only behavior-level
+  coverage via their callers — [tests.md][tests] requires a
+  test by the function's own name —
+  [plan/2608301918][2608301918].
+- `internal/lint/runcache.go`'s `RunCache` caches state across
+  every file in a whole `engine.Run` pass, which answers a
+  different question than [go.md][go]'s stated charter for
+  `internal/lint` ("model a parsed Markdown file"). Closer to
+  `internal/engine`'s job ("orchestrate rules over files; owns
+  the run loop"). Not an import-cycle or forbidden-import
+  violation — a package-boundary tax per go.md's "Split a
+  package by question," now 676 lines and ten cache slots —
+  [plan/2608301919][2608301919].
+
+### nice-to-have (2026-08-30)
+
+- `internal/rules/overrepetition/rule.go` and
+  `internal/rules/occurrence/rule.go` independently reimplement
+  the same file/section/paragraph scope-walking dispatch shape.
+  No cross-import (clean per go.md's DIP rule); [go.md][go]'s
+  refactor-moves precedent ("lift a shared dependency up ...
+  once two rules needed the same shape") would apply to a
+  future cleanup. No plan filed.
+- `cmd/mdsmith/query.go`'s `readFrontMatterRaw` reimplements a
+  slice of front-matter parsing that overlaps
+  `internal/lint`'s charter. Worth lifting into
+  `internal/lint` (e.g. `lint.FrontMatterMap`) alongside the
+  existing `StripFrontMatter` next time that file is touched.
+  No plan filed.
+
+[go]: architecture/go.md
+[tests]: architecture/tests.md
+[cross]: architecture/cross-system.md
+[2608021916]: ../../plan/2608021916_arch-fix-githooks-package-split.md
+[2608091910]: ../../plan/2608091910_arch-fix-mds073-collision.md
+[2608301918]: ../../plan/2608301918_arch-fix-touched-set-unit-tests-0830.md
+[2608301919]: ../../plan/2608301919_arch-fix-runcache-package-placement.md
 
 ## Audit 2026-08-23 (range: 2ab4b29..b706d76)
 
@@ -62,9 +176,6 @@ see the linked PR once opened.
 ### nice-to-have (2026-08-23)
 
 None found this cycle.
-
-[go]: architecture/go.md
-[2608021916]: ../../plan/2608021916_arch-fix-githooks-package-split.md
 
 ## Audit 2026-08-16 (range: 2ab4b29..81f0d96)
 
@@ -148,89 +259,3 @@ None.
   exhaustively tested. No plan filed.
 
 [2608161914]: ../../plan/2608161914_arch-fix-touched-set-unit-tests.md
-
-## Audit 2026-08-09 (range: 6680ff5..2ab4b29)
-
-100 commits, 148 files touched (92 Go files).
-
-New packages this cycle:
-
-- `internal/foreignregion` — foreign managed-region
-  protection for check/fix.
-- `internal/convention` — extracted convention model.
-
-New opt-in rules this cycle:
-
-- `internal/rules/occurrence` (MDS060).
-- `internal/rules/slidevstructure` (MDS073).
-
-No rule-to-rule imports. No reverse-layer imports. No
-Liskov breaks. `cmd/mdsmith/main.go` (709 lines) stayed well
-under the ~1000-line threshold, as did
-`internal/lsp/server.go`/`symbols.go` (554/511 lines).
-
-Clean surfaces, verified:
-
-- `internal/mdpath` consolidation: `IsMarkdownPath` grew into
-  a single source of truth (`Extensions`, `FileGlobs`,
-  `RecursiveGlobs`, `HasMarkdownExt`) now consumed by
-  `internal/lsp`, `internal/config`, and the merge-driver
-  include set — SRP fix per go.md's "package answers one
-  question." Every function has an exact-name test.
-- `cmd/mdsmith/init.go` split: extracted from `main.go` with
-  full dedicated-test coverage — 39 `Test*` functions cover
-  all 13 functions, including error paths.
-- `internal/rules/crossfilereferenceintegrity`'s
-  double-checked-locking memoization
-  (`cachedGlobSettingsErr`) is pinned by dedicated tests
-  following the `TestReceiver_Foo` naming convention.
-
-### blockers (2026-08-09)
-
-- `MDS073` is claimed by two unrelated, independently
-  registered diagnostics. `internal/rules/slidevstructure/rule.go:52`
-  returns `"MDS073"` for the Slidev slide-structure rule
-  (registered in `internal/rules/all/all.go`, documented at
-  `internal/rules/MDS073-slide-structure/README.md`).
-  `internal/foreignregion/scan.go:25` independently defines
-  `RuleID = "MDS073"` for the malformed-marker-pair
-  diagnostic (wired into `internal/engine/runner.go` and
-  `internal/fix/fix.go`, documented at
-  `docs/reference/foreign-regions.md:76`). Both landed the
-  same day (2026-07-19) — slide-structure was renumbered
-  `MDS072 -> MDS073` in `7e4925a` while the foreign-region
-  feature independently claimed `MDS073` in parallel commits
-  — an undetected rebase/merge collision.
-  [cross-system.md][cross] treats rule IDs as part of the
-  public `.mdsmith.yml`/CLI/docs contract; no test in
-  `internal/integration/` or `internal/rule/` enforces
-  uniqueness across `rule.All()` plus out-of-band IDs like
-  foreign-region's. Fixed by renumbering the foreign-region
-  diagnostic to the next free ID and adding a uniqueness
-  contract test — [plan/2608091910][2608091910].
-
-### tax (2026-08-09)
-
-- `internal/rules/occurrence/rule.go` has 18 non-trivial
-  private helpers with no dedicated unit test by name
-  (`countCombinedInRange`, `searchText`, `applyScope`, …).
-  All are covered indirectly by 47 behavior-level
-  `TestCheck_*`/`TestApplySettings_*` cases, but
-  [tests.md][tests] requires a test by the function's own
-  name, and the pre-existing sibling rule
-  `paragraphstructure` follows that convention for every
-  helper — [plan/2608091911][2608091911].
-- `internal/rules/slidevstructure/rule.go` has 11
-  non-trivial private helpers (`checkSlide`, `slideAnchor`,
-  `nearest`, …) in the same shape — covered behaviorally by
-  35 `Test*` cases but not by name —
-  [plan/2608091911][2608091911].
-
-[cross]: architecture/cross-system.md
-[tests]: architecture/tests.md
-[2608091910]: ../../plan/2608091910_arch-fix-mds073-collision.md
-[2608091911]: ../../plan/2608091911_arch-fix-missing-unit-tests.md
-
-### nice-to-have (2026-08-09)
-
-None found this cycle beyond the tax items above.

--- a/internal/backlinks/backlinks.go
+++ b/internal/backlinks/backlinks.go
@@ -1,0 +1,337 @@
+// Package backlinks resolves which workspace files link to a given
+// target path (optionally scoped to an anchor). It owns the
+// link/wikilink target-matching algorithm behind `mdsmith list
+// backlinks`; cmd/mdsmith only parses flags and formats output.
+package backlinks
+
+import (
+	"fmt"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/jeduden/mdsmith/internal/bytelimit"
+	"github.com/jeduden/mdsmith/internal/config"
+	"github.com/jeduden/mdsmith/internal/globpath"
+	"github.com/jeduden/mdsmith/internal/linkgraph"
+	"github.com/jeduden/mdsmith/internal/lint"
+)
+
+// Record is one incoming link to the queried target.
+//
+// Kind is set to "wikilink" only when the record came from an
+// Obsidian-style `[[Page]]` link; for ordinary Markdown links Kind
+// stays empty and is omitted from JSON, so the historical
+// {source, line, text, target} shape every existing consumer reads
+// is preserved unchanged.
+//
+// Alias and Embed are only meaningful when Kind == "wikilink":
+//   - Alias is the `|alias` half of `[[Page|alias]]`, empty when
+//     the source had no alias.
+//   - Embed is true when the source used `![[...]]` rather than
+//     `[[...]]`.
+//
+// All three of Kind, Alias, and Embed are omitempty so a JSON
+// document of standard-link records is byte-for-byte the same as
+// before the wikilink fields were added.
+type Record struct {
+	Source string `json:"source"`
+	Line   int    `json:"line"`
+	Text   string `json:"text"`
+	Target string `json:"target"`
+	Kind   string `json:"kind,omitempty"`
+	Alias  string `json:"alias,omitempty"`
+	Embed  bool   `json:"embed,omitempty"`
+}
+
+// Collect walks every source file in files, extracts its outgoing
+// links via linkgraph, and returns one record per link whose resolved
+// workspace-relative target equals wantTarget. When wantAnchor is
+// non-empty, the link's anchor must also match (after slugifying).
+// includePatterns, when non-empty, filters source paths.
+// ignorePatterns are config `ignore:` globs; matched sources are
+// skipped so backlinks output respects the same scope as check/fix.
+//
+// stripFrontMatter must mirror the config's frontMatter setting so
+// reported line numbers match MDS027 / the engine for the same file.
+//
+// Per-file read or parse failures do not abort the walk; instead they
+// are collected and returned so the caller can surface them on stderr
+// alongside whatever results were produced.
+func Collect(
+	files []string,
+	rootDir, wantTarget, wantAnchor string,
+	includePatterns, ignorePatterns []string,
+	maxBytes int64,
+	stripFrontMatter bool,
+) ([]Record, []error) {
+	wantAnchorSlug := ""
+	if wantAnchor != "" {
+		wantAnchorSlug = linkgraph.NormalizeAnchor(wantAnchor)
+	}
+
+	// Build the workspace wikilink index once per Collect call so a
+	// corpus with N source files x M distinct wikilink targets does
+	// one fs.WalkDir instead of N x M. Both this command and MDS027
+	// route through linkgraph.WikilinkIndexFor so the build/cache
+	// semantics live in one place.
+	//
+	// When rootDir is empty (e.g. unit-test calls with files in the
+	// current directory and no resolved workspace root), wikilink
+	// resolution is skipped entirely: extractBacklinksFromSource
+	// leaves f.RootFS unset, and appendWikilinkBacklinks returns
+	// early without producing any wikilink rows. Standard Markdown
+	// links still surface.
+	var index *linkgraph.WikilinkIndex
+	if rootDir != "" {
+		index = linkgraph.WikilinkIndexFor(nil, "", lint.OpenRootFS(rootDir))
+	}
+
+	var records []Record
+	var errs []error
+	for _, src := range files {
+		srcRel := relPath(src, rootDir)
+		// Self-links count: the contract is "every workspace file
+		// that links to <target>", and a file that links to itself
+		// satisfies that as literally as any other source.
+		if !sourceMatches(srcRel, includePatterns) ||
+			config.IsIgnored(ignorePatterns, srcRel) {
+			continue
+		}
+		rs, err := extractBacklinksFromSource(
+			src, srcRel, rootDir, wantTarget, wantAnchorSlug,
+			maxBytes, stripFrontMatter, index,
+		)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		records = append(records, rs...)
+	}
+	sort.SliceStable(records, func(i, j int) bool {
+		if records[i].Source != records[j].Source {
+			return records[i].Source < records[j].Source
+		}
+		return records[i].Line < records[j].Line
+	})
+	return records, errs
+}
+
+// extractBacklinksFromSource reads one source file, parses it, and
+// returns the backlink records (and any read/parse error) for links
+// that resolve to wantTarget. wantAnchorSlug is the already-slugified
+// anchor query, or "" to match any anchor.
+func extractBacklinksFromSource(
+	src, srcRel, rootDir, wantTarget, wantAnchorSlug string,
+	maxBytes int64, stripFrontMatter bool,
+	index *linkgraph.WikilinkIndex,
+) ([]Record, error) {
+	data, err := bytelimit.ReadFileLimited(src, maxBytes)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", srcRel, err)
+	}
+	// Reuse the lint pipeline's front-matter handling so line numbers
+	// in records match what users see in editors. Mirror the config's
+	// frontMatter setting so backlinks stays aligned with MDS027 when
+	// stripping is turned off.
+	//
+	// NewFileFromSource only errors when NewFile errors, and NewFile
+	// never errors — goldmark always returns an AST. The discard keeps
+	// the linter happy without preserving an unreachable branch.
+	f, _ := lint.NewFileFromSource(src, data, stripFrontMatter) //nolint:errcheck
+	// Wikilink resolution needs the workspace root: ResolveWikiLink
+	// walks the fs.FS to find candidates. Standard Markdown link
+	// resolution operates on the source-relative path and never reads
+	// f.RootFS, so this is a wikilink-only requirement.
+	if rootDir != "" {
+		f.SetRootDir(rootDir)
+	}
+	var out []Record
+	for _, link := range linkgraph.ExtractLinks(f) {
+		t := link.Target
+		// Skip same-file anchor refs: backlinks only surfaces cross-
+		// file edges. linkgraph guarantees a non-empty Path whenever
+		// LocalAnchor is false.
+		if t.LocalAnchor {
+			continue
+		}
+		resolved := resolveLinkTarget(srcRel, t.Path)
+		if resolved == "" || resolved != wantTarget {
+			continue
+		}
+		if wantAnchorSlug != "" && linkgraph.NormalizeAnchor(t.Anchor) != wantAnchorSlug {
+			continue
+		}
+		out = append(out, Record{
+			Source: srcRel,
+			// ExtractLinks returns body-relative lines (rules need
+			// that for the engine's offset-adjustment); the CLI shows
+			// file-relative line numbers, so add f.LineOffset back in.
+			Line:   link.Line + f.LineOffset,
+			Text:   link.Text(f.Source),
+			Target: t.Raw,
+		})
+	}
+	out = appendWikilinkBacklinks(out, f, srcRel, wantTarget, wantAnchorSlug, index)
+	return out, nil
+}
+
+// appendWikilinkBacklinks scans f for Obsidian-style wikilinks whose
+// resolved workspace-relative target matches wantTarget. Resolution
+// uses the same shortest-path algorithm MDS027 applies, sandboxed to
+// the file's root. Wikilinks are extracted unconditionally — the
+// scan is cheap and the user querying backlinks already opted in by
+// running the command.
+//
+// When a prebuilt index is supplied, every wikilink resolves via
+// O(1) map lookups; otherwise resolution falls back to per-call
+// fs.WalkDir, memoized per target within this file.
+func appendWikilinkBacklinks(
+	out []Record,
+	f *lint.File,
+	srcRel, wantTarget, wantAnchorSlug string,
+	index *linkgraph.WikilinkIndex,
+) []Record {
+	wikilinks := linkgraph.ExtractWikiLinks(f)
+	if len(wikilinks) == 0 {
+		return out
+	}
+	root := f.RootFS
+	if root == nil && index == nil {
+		return out
+	}
+	type resolveResult struct {
+		path string
+		ok   bool
+	}
+	cache := map[string]resolveResult{}
+	for _, wl := range wikilinks {
+		r, cached := cache[wl.Target]
+		if !cached {
+			if index != nil {
+				r.path, r.ok = index.Resolve(wl.Target)
+			} else {
+				r.path, r.ok = linkgraph.ResolveWikiLink(root, srcRel, wl.Target)
+			}
+			cache[wl.Target] = r
+		}
+		if !r.ok || r.path != wantTarget {
+			continue
+		}
+		if wantAnchorSlug != "" && linkgraph.NormalizeAnchor(wl.Anchor) != wantAnchorSlug {
+			continue
+		}
+		// Visible text mirrors what a reader would see: the alias
+		// when one is present; otherwise the target-as-written
+		// (target + "#anchor" if the source carried a fragment).
+		// Using wl.Target alone would drop the anchor portion from
+		// the JSON `text` field for `[[page#Section]]` and break
+		// downstream round-tripping.
+		text := wl.Alias
+		if text == "" {
+			text = wikilinkTargetString(wl)
+		}
+		out = append(out, Record{
+			Source: srcRel,
+			Line:   wl.Line + f.LineOffset,
+			Text:   text,
+			Target: wikilinkTargetString(wl),
+			Kind:   "wikilink",
+			Alias:  wl.Alias,
+			Embed:  wl.Embed,
+		})
+	}
+	return out
+}
+
+// wikilinkTargetString renders just the target+anchor of wl as it
+// appeared in the source — the destination half a Markdown link's
+// Target field would carry. Alias and embed prefix are dropped so
+// the field reflects "where does this point", not "how does it look".
+func wikilinkTargetString(wl linkgraph.WikiLink) string {
+	if wl.Anchor == "" {
+		return wl.Target
+	}
+	return wl.Target + "#" + wl.Anchor
+}
+
+// relPath returns p relative to rootDir using forward slashes. When
+// rootDir is empty or filepath.Rel cannot relate the paths, p is
+// returned as-is with separators normalized.
+//
+// This intentionally duplicates cmd/mdsmith's workspaceRelativePath
+// rather than importing it: cmd/mdsmith depends on internal/backlinks,
+// never the reverse, and this is a small, stable, independently
+// tested pure function — cheaper to keep in both places than to widen
+// this package's exports for a helper that four other CLI subcommands
+// also use unrelated to backlinks.
+func relPath(p, rootDir string) string {
+	fallback := strings.TrimPrefix(filepath.ToSlash(p), "./")
+	if rootDir == "" {
+		return fallback
+	}
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return fallback
+	}
+	absRoot, err := filepath.Abs(rootDir)
+	if err != nil {
+		return fallback
+	}
+	rel, err := filepath.Rel(absRoot, abs)
+	if err != nil {
+		return fallback
+	}
+	return filepath.ToSlash(rel)
+}
+
+// resolveLinkTarget joins srcRel's directory with the link's path and
+// returns the workspace-relative result. Both inputs use forward
+// slashes. Absolute paths (including Windows drive letters and UNC
+// prefixes) and ones that escape the workspace root return "" so
+// callers treat them as "outside the graph".
+func resolveLinkTarget(srcRel, linkPath string) string {
+	srcRel = strings.ReplaceAll(srcRel, `\`, `/`)
+	linkPath = strings.ReplaceAll(linkPath, `\`, `/`)
+	if isAbsOrDriveOrUNC(srcRel) || isAbsOrDriveOrUNC(linkPath) {
+		return ""
+	}
+	dir := path.Dir(srcRel)
+	cleaned := path.Clean(path.Join(dir, linkPath))
+	if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return ""
+	}
+	return cleaned
+}
+
+// isAbsOrDriveOrUNC reports whether p is absolute under any of the
+// schemes mdsmith targets: POSIX-style leading `/`, Windows drive
+// letters like `C:/`, or UNC prefixes like `//host`. `path.IsAbs`
+// alone misses the Windows forms because the path package is Unix-only.
+func isAbsOrDriveOrUNC(p string) bool {
+	if path.IsAbs(p) {
+		return true
+	}
+	if len(p) >= 2 && p[1] == ':' {
+		c := p[0]
+		if (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') {
+			return true
+		}
+	}
+	return strings.HasPrefix(p, "//")
+}
+
+// sourceMatches reports whether src should be considered, given the
+// list of --include globs. An empty list lets every source through.
+func sourceMatches(src string, includePatterns []string) bool {
+	if len(includePatterns) == 0 {
+		return true
+	}
+	for _, pat := range includePatterns {
+		if globpath.Match(pat, src) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/backlinks/backlinks.go
+++ b/internal/backlinks/backlinks.go
@@ -256,9 +256,17 @@ func wikilinkTargetString(wl linkgraph.WikiLink) string {
 	return wl.Target + "#" + wl.Anchor
 }
 
+// relFn computes a relative path between two absolute paths.
+// Package-level so tests can inject a failure: on a Unix CI runner,
+// filepath.Rel can only ever error given a Windows volume mismatch
+// neither input here can produce, so relPath's fallback branch is
+// otherwise untestable on the platform this project's coverage gate
+// runs on.
+var relFn = filepath.Rel
+
 // relPath returns p relative to rootDir using forward slashes. When
-// rootDir is empty or filepath.Rel cannot relate the paths, p is
-// returned as-is with separators normalized.
+// rootDir is empty or relFn cannot relate the paths, p is returned
+// as-is with separators normalized.
 //
 // This intentionally duplicates cmd/mdsmith's workspaceRelativePath
 // rather than importing it: cmd/mdsmith depends on internal/backlinks,
@@ -279,7 +287,7 @@ func relPath(p, rootDir string) string {
 	if err != nil {
 		return fallback
 	}
-	rel, err := filepath.Rel(absRoot, abs)
+	rel, err := relFn(absRoot, abs)
 	if err != nil {
 		return fallback
 	}

--- a/internal/backlinks/backlinks_test.go
+++ b/internal/backlinks/backlinks_test.go
@@ -1,0 +1,332 @@
+package backlinks
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/jeduden/mdsmith/internal/linkgraph"
+	"github.com/jeduden/mdsmith/internal/lint"
+)
+
+func TestResolveLinkTarget(t *testing.T) {
+	cases := []struct {
+		name     string
+		src      string
+		linkPath string
+		want     string
+	}{
+		{"sibling", "docs/index.md", "api.md", "docs/api.md"},
+		{"dot-prefix", "docs/index.md", "./api.md", "docs/api.md"},
+		{"parent dir", "docs/sub/index.md", "../api.md", "docs/api.md"},
+		{"two levels up", "plan/045.md", "../docs/api.md", "docs/api.md"},
+		{"escapes root", "docs/api.md", "../../etc/passwd", ""},
+		{"absolute link", "docs/api.md", "/etc/passwd", ""},
+		{"absolute source", "/abs/docs/api.md", "guide.md", ""},
+		// Windows-style absolutes — path.IsAbs alone misses these.
+		{"drive letter link", "docs/api.md", "C:/Windows/system.md", ""},
+		{"drive letter source", "C:/docs/api.md", "guide.md", ""},
+		{"UNC link", "docs/api.md", "//server/share/file.md", ""},
+		{"UNC source", "//server/share/api.md", "guide.md", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveLinkTarget(tc.src, tc.linkPath)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestIsAbsOrDriveOrUNC(t *testing.T) {
+	assert.True(t, isAbsOrDriveOrUNC("/etc/passwd"))
+	assert.True(t, isAbsOrDriveOrUNC("C:/Windows"))
+	assert.True(t, isAbsOrDriveOrUNC("//server/share"))
+	assert.False(t, isAbsOrDriveOrUNC("docs/api.md"))
+	assert.False(t, isAbsOrDriveOrUNC(""))
+}
+
+func TestRelPath_EmptyRootDir(t *testing.T) {
+	// When rootDir is empty, the helper just strips a leading "./"
+	// and forwards the path through.
+	assert.Equal(t, "docs/api.md", relPath("./docs/api.md", ""))
+	assert.Equal(t, "docs/api.md", relPath("docs/api.md", ""))
+}
+
+func TestSourceMatches(t *testing.T) {
+	assert.True(t, sourceMatches("docs/api.md", nil))
+	assert.True(t, sourceMatches("docs/api.md", []string{"docs/**"}))
+	assert.False(t, sourceMatches("plan/045.md", []string{"docs/**"}))
+	assert.True(t, sourceMatches("plan/045.md", []string{"docs/**", "plan/**"}))
+}
+
+func TestWikilinkTargetString(t *testing.T) {
+	assert.Equal(t, "page", wikilinkTargetString(linkgraph.WikiLink{Target: "page"}))
+	assert.Equal(t, "page#Section", wikilinkTargetString(linkgraph.WikiLink{Target: "page", Anchor: "Section"}))
+}
+
+// setupCollectFixture creates a small workspace with three distinct
+// sources linking to docs/api.md so the end-to-end tests can share
+// one filesystem layout.
+func setupCollectFixture(t *testing.T) (root string, files []string) {
+	t.Helper()
+	root = t.TempDir()
+	mkdir := func(rel string) {
+		require.NoError(t, os.MkdirAll(filepath.Join(root, rel), 0o755))
+	}
+	write := func(rel, body string) {
+		require.NoError(t, os.WriteFile(filepath.Join(root, rel), []byte(body), 0o644))
+	}
+	mkdir("docs")
+	mkdir("plan")
+	mkdir("docs/sub")
+	write("docs/api.md", "# API\n\n## Authentication\n\n## Endpoints\n")
+	write("docs/index.md", "# Index\n\nSee [API reference](api.md).\n")
+	write("docs/sub/guide.md", "# Guide\n\nUse [api docs](../api.md#authentication).\n")
+	write("plan/045_api-overhaul.md", "# Plan\n\n[api](../docs/api.md)\n")
+	// File that does NOT link to api.md.
+	write("docs/changelog.md", "# Changelog\n\n[plan](../plan/045_api-overhaul.md)\n")
+
+	files = []string{
+		filepath.Join(root, "docs/api.md"),
+		filepath.Join(root, "docs/changelog.md"),
+		filepath.Join(root, "docs/index.md"),
+		filepath.Join(root, "docs/sub/guide.md"),
+		filepath.Join(root, "plan/045_api-overhaul.md"),
+	}
+	return root, files
+}
+
+// TestCollect_End2End covers the path/anchor combinations the
+// backlinks command's acceptance criteria call out: three sources,
+// anchor scoping, include filter, limit.
+func TestCollect_End2End(t *testing.T) {
+	root, files := setupCollectFixture(t)
+
+	t.Run("three sources, no anchor", func(t *testing.T) {
+		got, errs := Collect(files, root, "docs/api.md", "", nil, nil, 0, true)
+		require.Empty(t, errs)
+		require.Len(t, got, 3)
+		assert.Equal(t, "docs/index.md", got[0].Source)
+		assert.Equal(t, "docs/sub/guide.md", got[1].Source)
+		assert.Equal(t, "plan/045_api-overhaul.md", got[2].Source)
+	})
+
+	t.Run("anchor scopes to one source", func(t *testing.T) {
+		got, errs := Collect(files, root, "docs/api.md", "authentication", nil, nil, 0, true)
+		require.Empty(t, errs)
+		require.Len(t, got, 1)
+		assert.Equal(t, "docs/sub/guide.md", got[0].Source)
+	})
+
+	t.Run("anchor with no hits returns empty", func(t *testing.T) {
+		got, errs := Collect(files, root, "docs/api.md", "no-such-section", nil, nil, 0, true)
+		assert.Empty(t, errs)
+		assert.Empty(t, got)
+	})
+
+	t.Run("include filter excludes plan/", func(t *testing.T) {
+		got, errs := Collect(files, root, "docs/api.md", "", []string{"docs/**"}, nil, 0, true)
+		require.Empty(t, errs)
+		require.Len(t, got, 2)
+		assert.Equal(t, "docs/index.md", got[0].Source)
+		assert.Equal(t, "docs/sub/guide.md", got[1].Source)
+	})
+
+	t.Run("unreadable source surfaces as error", func(t *testing.T) {
+		// A path that does not exist on disk: ReadFileLimited fails;
+		// Collect captures the error rather than swallowing.
+		bad := filepath.Join(root, "does-not-exist.md")
+		filesWithBad := append([]string{bad}, files...)
+		got, errs := Collect(filesWithBad, root, "docs/api.md", "", nil, nil, 0, true)
+		// The other files still contribute results.
+		assert.NotEmpty(t, got)
+		require.Len(t, errs, 1)
+		assert.Contains(t, errs[0].Error(), "does-not-exist.md")
+	})
+}
+
+func TestCollect_LocalAnchorSkipped(t *testing.T) {
+	// Source contains only a same-file anchor link, no cross-file
+	// reference to the target. linkgraph yields a LocalAnchor=true
+	// link; Collect must skip it without trying to resolve a path
+	// target.
+	root, files := setupCollectFixture(t)
+	anchorOnly := filepath.Join(root, "anchor-only.md")
+	require.NoError(t, os.WriteFile(anchorOnly,
+		[]byte("# Intro\n\nJump to [section](#section).\n\n## Section\n"), 0o644))
+	filesWithAnchor := append([]string{anchorOnly}, files...)
+	got, errs := Collect(filesWithAnchor, root, "docs/api.md", "", nil, nil, 0, true)
+	assert.Empty(t, errs)
+	// Same three matches as before; anchor-only.md contributes nothing.
+	assert.Len(t, got, 3)
+}
+
+func TestCollect_IgnorePatternsExclude(t *testing.T) {
+	// `plan/**` ignores the plan/* source that links to api.md;
+	// the other two sources still produce records.
+	root, files := setupCollectFixture(t)
+	got, errs := Collect(
+		files, root, "docs/api.md", "",
+		nil, []string{"plan/**"}, 0, true,
+	)
+	require.Empty(t, errs)
+	require.Len(t, got, 2)
+	for _, r := range got {
+		assert.NotContains(t, r.Source, "plan/")
+	}
+}
+
+// TestCollect_SelfLink confirms self-references count as incoming
+// edges. The contract is "every workspace file that links to
+// <target>" — a file that links to itself satisfies that as
+// literally as any other source.
+func TestCollect_SelfLink(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "docs"), 0o755))
+	// docs/api.md links to itself via `api.md`.
+	require.NoError(t, os.WriteFile(filepath.Join(root, "docs", "api.md"),
+		[]byte("# API\n\nSee [back to top](api.md).\n"), 0o644))
+	files := []string{filepath.Join(root, "docs", "api.md")}
+
+	got, errs := Collect(files, root, "docs/api.md", "", nil, nil, 0, true)
+	require.Empty(t, errs)
+	require.Len(t, got, 1)
+	assert.Equal(t, "docs/api.md", got[0].Source)
+	assert.Equal(t, "api.md", got[0].Target)
+}
+
+// TestCollect_FrontMatterStrippingDisabled verifies the
+// stripFrontMatter parameter is honored. When set to false (matching
+// `frontMatter: false` in config), Collect parses the entire file
+// including its front matter — line numbers stay in raw file
+// coordinates rather than body-relative.
+func TestCollect_FrontMatterStrippingDisabled(t *testing.T) {
+	root, files := setupCollectFixture(t)
+	fmSrc := filepath.Join(root, "fm-src.md")
+	require.NoError(t, os.WriteFile(fmSrc,
+		[]byte("---\ntitle: x\n---\n# H\n\nSee [api](docs/api.md).\n"), 0o644))
+	filesWithFM := append([]string{fmSrc}, files...)
+	got, errs := Collect(filesWithFM, root, "docs/api.md", "", nil, nil, 0, false)
+	require.Empty(t, errs)
+	var fmRec *Record
+	for i := range got {
+		if got[i].Source == "fm-src.md" {
+			fmRec = &got[i]
+			break
+		}
+	}
+	require.NotNil(t, fmRec)
+	// Front matter spans 3 lines; the link sits on the 6th line.
+	// stripFrontMatter=false → no LineOffset adjustment → 6.
+	assert.Equal(t, 6, fmRec.Line)
+}
+
+// TestCollect_SortStable verifies that two records from the same
+// source file are returned in line order (the secondary key in the
+// SliceStable comparator).
+func TestCollect_SortStable(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "target.md"), []byte("# T\n"), 0o644))
+	// Two links to target.md from the SAME source: line 3 and line 5.
+	body := "# Src\n\nFirst [a](target.md), and\n\nsecond [b](target.md).\n"
+	require.NoError(t, os.WriteFile(filepath.Join(root, "src.md"), []byte(body), 0o644))
+
+	files := []string{filepath.Join(root, "src.md"), filepath.Join(root, "target.md")}
+	got, errs := Collect(files, root, "target.md", "", nil, nil, 0, true)
+	require.Empty(t, errs)
+	require.Len(t, got, 2)
+	assert.Equal(t, "src.md", got[0].Source)
+	assert.Equal(t, "src.md", got[1].Source)
+	assert.Less(t, got[0].Line, got[1].Line, "same-source records sort by line")
+}
+
+func TestCollect_Wikilinks(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "page.md"), []byte("# Page\n\n## Section\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "other.md"),
+		[]byte("# Other\n\nSee [[page]] and [[page|alias]].\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "anchored.md"),
+		[]byte("# Anchored\n\n[[page#Section]]\n"), 0o644))
+	files := []string{
+		filepath.Join(root, "anchored.md"),
+		filepath.Join(root, "other.md"),
+		filepath.Join(root, "page.md"),
+	}
+
+	t.Run("matches both wikilink shapes", func(t *testing.T) {
+		got, errs := Collect(files, root, "page.md", "", nil, nil, 0, true)
+		require.Empty(t, errs)
+		// Expect three wikilink hits — two on other.md, one on anchored.md.
+		require.Len(t, got, 3)
+		for _, r := range got {
+			assert.Equal(t, "wikilink", r.Kind, "all wikilink hits must carry kind=wikilink")
+		}
+	})
+
+	t.Run("anchor scoping", func(t *testing.T) {
+		got, errs := Collect(files, root, "page.md", "section", nil, nil, 0, true)
+		require.Empty(t, errs)
+		require.Len(t, got, 1)
+		assert.Equal(t, "anchored.md", got[0].Source)
+		assert.Equal(t, "wikilink", got[0].Kind)
+		assert.Equal(t, "page#Section", got[0].Target)
+		// `text` is the visible link text — for anchor-only wikilinks
+		// the full target-as-written, not the bare stem. Setting
+		// Text=wl.Target alone would drop the `#Section` half and
+		// break JSON round-tripping.
+		assert.Equal(t, "page#Section", got[0].Text)
+	})
+}
+
+func TestAppendWikilinkBacklinks_FallbackToPerCallWalk(t *testing.T) {
+	// The Collect public path always pairs index with RootFS; calling
+	// appendWikilinkBacklinks directly with a nil index but a
+	// populated RootFS exercises the per-call fs.WalkDir fallback,
+	// which would otherwise rot if the helper API ever gets reused
+	// without the index.
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "page.md"), []byte("# P\n"), 0o644))
+	srcPath := filepath.Join(root, "src.md")
+	require.NoError(t, os.WriteFile(srcPath, []byte("# S\n\n[[page]]\n"), 0o644))
+	data, err := os.ReadFile(srcPath)
+	require.NoError(t, err)
+	f, err := lint.NewFileFromSource(srcPath, data, true)
+	require.NoError(t, err)
+	f.RootFS = os.DirFS(root)
+	got := appendWikilinkBacklinks(nil, f, "src.md", "page.md", "", nil)
+	require.Len(t, got, 1)
+	// Target on a wikilink record is the source-form `[[target]]`,
+	// not the resolved filename; resolution matches "page" against
+	// "page.md" but the record carries the bare stem.
+	assert.Equal(t, "page", got[0].Target)
+}
+
+func TestAppendWikilinkBacklinks_NoRootFS(t *testing.T) {
+	// extractBacklinksFromSource leaves f.RootFS nil whenever
+	// rootDir == "" — appendWikilinkBacklinks then has no workspace
+	// to walk and must return the input slice untouched.
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "src.md"),
+		[]byte("# S\n\n[[page]]\n"), 0o644))
+	files := []string{filepath.Join(root, "src.md")}
+	got, errs := Collect(files, "", "page.md", "", nil, nil, 0, true)
+	require.Empty(t, errs)
+	assert.Empty(t, got)
+}
+
+func TestAppendWikilinkBacklinks_UnrelatedTargetSkipped(t *testing.T) {
+	// A wikilink that resolves to a different file than wantTarget
+	// exercises the `r.path != wantTarget` continue branch.
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "other.md"),
+		[]byte("# Other\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "src.md"),
+		[]byte("# S\n\n[[other]]\n"), 0o644))
+	files := []string{filepath.Join(root, "src.md")}
+	got, errs := Collect(files, root, "page.md", "", nil, nil, 0, true)
+	require.Empty(t, errs)
+	assert.Empty(t, got)
+}

--- a/internal/backlinks/backlinks_test.go
+++ b/internal/backlinks/backlinks_test.go
@@ -55,6 +55,38 @@ func TestRelPath_EmptyRootDir(t *testing.T) {
 	assert.Equal(t, "docs/api.md", relPath("docs/api.md", ""))
 }
 
+// chdirToRemoved changes into a fresh temp dir and then deletes it, so
+// the process has no valid working directory and os.Getwd fails.
+// t.Chdir restores the original directory at cleanup. This drives the
+// filepath.Abs-error fallbacks that a normal filesystem never reaches
+// — the same pattern cmd/mdsmith's coverage100_test.go uses for the
+// sibling workspaceRelativePath this function duplicates.
+func chdirToRemoved(t *testing.T) {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "mdsmith-backlinks-nowd-*")
+	require.NoError(t, err)
+	t.Chdir(dir)
+	require.NoError(t, os.Remove(dir))
+}
+
+func TestRelPath_AbsPathError(t *testing.T) {
+	// With no valid cwd, filepath.Abs(p) fails on a relative p before
+	// rootDir is even consulted; relPath falls back to the trimmed
+	// input.
+	chdirToRemoved(t)
+	assert.Equal(t, "docs/api.md", relPath("docs/api.md", "root"))
+}
+
+func TestRelPath_AbsRootDirError(t *testing.T) {
+	// p is already absolute, so filepath.Abs(p) succeeds without a
+	// cwd; rootDir is relative, so filepath.Abs(rootDir) is the one
+	// that fails with no valid cwd. The fallback mirrors the
+	// original (absolute) p unchanged, since it never went through
+	// the rootDir-relative branch.
+	chdirToRemoved(t)
+	assert.Equal(t, "/abs/docs/api.md", relPath("/abs/docs/api.md", "root"))
+}
+
 func TestSourceMatches(t *testing.T) {
 	assert.True(t, sourceMatches("docs/api.md", nil))
 	assert.True(t, sourceMatches("docs/api.md", []string{"docs/**"}))

--- a/internal/backlinks/backlinks_test.go
+++ b/internal/backlinks/backlinks_test.go
@@ -1,8 +1,10 @@
 package backlinks
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -75,6 +77,23 @@ func TestRelPath_AbsPathError(t *testing.T) {
 	// input.
 	chdirToRemoved(t)
 	assert.Equal(t, "docs/api.md", relPath("docs/api.md", "root"))
+}
+
+func TestRelPath_RelError(t *testing.T) {
+	// filepath.Rel can only fail here on a Windows volume mismatch,
+	// unreachable given two paths built from filepath.Abs on the
+	// Unix runner this project's coverage gate uses. Swap relFn to
+	// drive the fallback branch directly.
+	orig := relFn
+	relFn = func(string, string) (string, error) {
+		return "", fmt.Errorf("simulated: can't relate paths")
+	}
+	t.Cleanup(func() { relFn = orig })
+
+	root := t.TempDir()
+	p := filepath.Join(root, "docs", "api.md")
+	got := relPath(p, root)
+	assert.Equal(t, strings.TrimPrefix(filepath.ToSlash(p), "./"), got)
 }
 
 func TestRelPath_AbsRootDirError(t *testing.T) {

--- a/plan/2608301918_arch-fix-touched-set-unit-tests-0830.md
+++ b/plan/2608301918_arch-fix-touched-set-unit-tests-0830.md
@@ -1,0 +1,83 @@
+---
+id: 2608301918
+title: >-
+  Add dedicated unit tests for the 2026-08-30 touched-set
+  tax findings
+status: "🔲"
+model: haiku
+summary: >-
+  WordFrequencyInto in internal/mdtext and three helpers in
+  internal/directivefiles landed with only behavior-level
+  coverage, not a dedicated unit test by name. Flagged by
+  the 2026-08-30 audit as tax.
+---
+# Add dedicated unit tests for the 2026-08-30 touched-set tax findings
+
+## Goal
+
+Give each function below its own unit test by name. Match
+the `TestFoo` convention [tests.md][tests] requires — the
+one every untouched sibling package already follows.
+
+## Background
+
+The 2026-08-30 audit (see [the audit log][audit-log]) swept
+every file touched since the prior checkpoint. It found four
+functions with no test carrying their own name. Each is
+exercised only indirectly through a caller's scenario test:
+
+- [internal/mdtext/wordfreq.go][wordfreq]:31 —
+  `WordFrequencyInto`, the zero-allocation inner loop that
+  accumulates word counts into a caller-owned, caller-cleared
+  map across multiple scope units. Covered only via
+  `WordFrequency`'s own tests in
+  [wordfreq_test.go][wordfreq-test], none of which call
+  `WordFrequencyInto` directly across repeated
+  accumulate/clear cycles — the exact zero-alloc-reuse
+  behavior it exists for.
+- [internal/directivefiles/directivefiles.go][directivefiles]:192,222,174 —
+  `openingFence`, `isClosingFence`, and `isIndentedCodeBlock`,
+  the fence-tracking helpers `hasDirectiveMarker` uses to skip
+  directive-marker matches inside code blocks. Covered only
+  indirectly via the `TestDiscoverFiles_Ignores*` and
+  `TestHasDirectiveMarker_*` fixture tests in
+  [directivefiles_test.go][directivefiles-test].
+
+Both are `tax`: neither sits on a public surface by itself
+(their callers already have tests).
+
+## Tasks
+
+1. Add `TestWordFrequencyInto` to
+   [wordfreq_test.go][wordfreq-test], calling
+   `WordFrequencyInto` directly across at least two
+   accumulate/`clear`/accumulate cycles on one reused map, so
+   the test exercises the reuse contract the doc comment
+   describes rather than a single one-shot call.
+2. Add `TestOpeningFence`, `TestIsClosingFence`, and
+   `TestIsIndentedCodeBlock` to
+   [directivefiles_test.go][directivefiles-test] as
+   table-driven tests covering the fence-character and
+   run-length matching each helper performs.
+3. Do not delete or duplicate the existing behavior-level
+   tests named above. They cover the public contract and
+   stay as-is.
+4. `go build ./...` passes.
+5. `go test ./internal/mdtext/... ./internal/directivefiles/...`
+   passes.
+
+## Acceptance Criteria
+
+- [ ] Every function named in the Background section has a
+      test carrying its own name.
+- [ ] `go test ./...` is green.
+- [ ] `go tool -modfile=tools/go.mod golangci-lint run`
+      reports no issues.
+- [ ] `mdsmith check .` is green.
+
+[audit-log]: ../docs/development/architecture-audit.md
+[tests]: ../docs/development/architecture/tests.md
+[wordfreq]: ../internal/mdtext/wordfreq.go
+[wordfreq-test]: ../internal/mdtext/wordfreq_test.go
+[directivefiles]: ../internal/directivefiles/directivefiles.go
+[directivefiles-test]: ../internal/directivefiles/directivefiles_test.go

--- a/plan/2608301919_arch-fix-runcache-package-placement.md
+++ b/plan/2608301919_arch-fix-runcache-package-placement.md
@@ -1,0 +1,101 @@
+---
+id: 2608301919
+title: >-
+  Relocate RunCache out of internal/lint
+status: "🔲"
+model: sonnet
+summary: >-
+  internal/lint/runcache.go's RunCache memoizes state across
+  every host file in one engine.Run pass — a cross-file,
+  whole-run scope that answers a different question than
+  internal/lint's stated charter of modeling one parsed
+  Markdown file. Flagged by the 2026-08-30 audit as tax.
+---
+# Relocate RunCache out of internal/lint
+
+## Goal
+
+Move `RunCache` to the package whose charter matches its
+actual scope. [go.md][go] calls this move "Split a package
+by question." Its behavior, and its callers' observable
+results, stay unchanged.
+
+## Background
+
+The 2026-08-30 audit (see [the audit log][audit-log]) found
+this scope mismatch:
+
+- [internal/lint][lint]'s stated charter is to model a
+  parsed Markdown file: source, AST, front matter,
+  diagnostics, caches, prose ranges — one file at a time.
+- [runcache.go][runcache]'s own doc comment says `RunCache`
+  "memoizes per-target-file reads ... across every host file
+  processed in one engine.Run pass" and is installed on
+  `engine.Runner.RunCache` — a cross-file, whole-run scope,
+  not a per-file one.
+- The file has grown to 676 lines and ten distinct cache
+  slots (`frontMatter`, `rawSchemaFile`, `includes`,
+  `anchors`, `wikilinks`, `globMatches`, `parsedSchema`,
+  `compiledCUE`, `duplicateParagraphs`, `corpusIndex`, plus
+  the `uniqueFieldIndex`/`uniqueFieldScopes` pair) — distinct
+  from the per-file `Memo` type internal/lint already owns.
+- [go.md][go]'s refactor-moves section: package-by-question
+  SRP smells split along the seam where the joined
+  responsibilities diverge. `internal/engine` is the package
+  whose stated job is "orchestrate rules over files; owns the
+  run loop" — the natural home for a whole-run cache.
+
+## Tasks
+
+1. Read [runcache.go][runcache] and its test file in full;
+   confirm every exported symbol (`RunCache` and its
+   methods) and every private helper type it depends on.
+2. Read every non-test caller before moving anything:
+   [internal/schema/compile_cache.go][schema-cc],
+   [internal/schema/validate.go][schema-validate],
+   [internal/engine/runner_cache.go][runner-cache],
+   [internal/engine/runner.go][runner],
+   [internal/rules/duplicatedcontent/rule.go][dup],
+   [internal/rules/requiredstructure/rule.go][reqstruct],
+   [internal/rules/requiredstructure/runcache_wiring.go][reqstruct-wiring],
+   [internal/linkgraph/wikilinks.go][wikilinks], and
+   [pkg/mdsmith/session.go][session].
+3. Move `RunCache` and its dependent types from
+   `internal/lint` to `internal/engine` (the package that
+   already owns the run loop `RunCache` is scoped to), or to
+   a new peer package if `internal/engine` would create an
+   import cycle with a current `RunCache` caller — check
+   this before choosing.
+4. Update every import across the files listed in task 2.
+5. Keep `internal/lint`'s per-file `Memo` type in place;
+   only the cross-file `RunCache` moves.
+6. `go build ./...` passes.
+7. `go test ./...` passes.
+8. `go tool -modfile=tools/go.mod golangci-lint run` reports
+   no issues.
+
+## Acceptance Criteria
+
+- [ ] `internal/lint`'s package doc no longer lists a
+      cross-file, whole-run cache among its responsibilities.
+- [ ] `RunCache` lives in the package whose stated charter is
+      "orchestrate rules over files."
+- [ ] No behavior change: `mdsmith check .` and `mdsmith lsp`
+      produce identical diagnostics before and after the
+      move.
+- [ ] `go test ./...` is green.
+- [ ] `mdsmith check .` is green.
+
+[audit-log]: ../docs/development/architecture-audit.md
+[go]: ../docs/development/architecture/go.md
+[lint]: ../internal/lint/
+[runcache]: ../internal/lint/runcache.go
+[schema-cc]: ../internal/schema/compile_cache.go
+[schema-validate]: ../internal/schema/validate.go
+[runner-cache]: ../internal/engine/runner_cache.go
+[runner]: ../internal/engine/runner.go
+[dup]: ../internal/rules/duplicatedcontent/rule.go
+[reqstruct]: ../internal/rules/requiredstructure/rule.go
+[reqstruct-wiring]: ../internal/rules/requiredstructure/runcache_wiring.go
+[wikilinks]: ../internal/linkgraph/wikilinks.go
+[session]: ../pkg/mdsmith/session.go


### PR DESCRIPTION
## Summary

- The 2026-08-30 architecture audit (`solid-architecture` skill, audit mode) swept every file touched since the last checkpoint (`b706d76..0ca0d2f`, 59 commits, ~130 files). No blockers found; full findings are in [the audit log](docs/development/architecture-audit.md#audit-2026-08-30-range-b706d760ca0d2f).
- The highest-priority finding: `cmd/mdsmith/backlinks.go` carried ~430 of 585 lines of the backlink target-matching algorithm (link/wikilink resolution, workspace-relative path math) inside the CLI package, violating [go.md](docs/development/architecture/go.md)'s "domain logic belongs in `pkg/mdsmith`, `internal/engine`, or their dependencies" rule.
- Fixed directly in this PR: extracted `Record`, `Collect`, and every private helper the matching algorithm needs into a new `internal/backlinks` package. `cmd/mdsmith/backlinks.go` now only parses flags, validates arguments, calls `backlinks.Collect`, and formats output — `runBacklinks` stays a thin dispatcher.
- `workspaceRelativePath` and `isAbsOrDriveOrUNC` stayed in `cmd/mdsmith` (shared by `deps.go` and `rename.go` too, not backlinks-specific); the new package carries its own small private duplicates of the two pure predicates it needs, rather than importing `cmd/mdsmith`, which would invert the dependency direction.
- No behavior change: existing unit tests moved to `internal/backlinks/backlinks_test.go` (CLI-layer tests — flag parsing, argument validation, output formatting — stay in `cmd/mdsmith/backlinks_unit_test.go`); the e2e test (`e2e_backlinks_test.go`) is untouched and still passes.
- Filed plans for the two remaining tax findings that weren't fixed in this PR: [plan/2608301918](plan/2608301918_arch-fix-touched-set-unit-tests-0830.md) (missing dedicated unit tests for `WordFrequencyInto` and three `internal/directivefiles` helpers) and [plan/2608301919](plan/2608301919_arch-fix-runcache-package-placement.md) (`internal/lint/runcache.go`'s `RunCache` answers a whole-run-scope question that belongs closer to `internal/engine`, not `internal/lint`'s per-file charter — a larger structural move deferred to its own plan).
- Two nice-to-have findings (duplicated scope-walking shape between `overrepetition`/`occurrence`; `query.go`'s `readFrontMatterRaw` overlapping `internal/lint`'s charter) are logged but not filed as plans, per the audit checklist's convention for that severity.
- Reshuffled the audit-log archive shards (`architecture-audit-archive.md`, `-archive-2.md`) to stay under the 300-line file-length budget after this cycle's entry landed.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (full suite green)
- [x] `go vet ./...`
- [x] `go tool -modfile=tools/go.mod golangci-lint run` (0 issues)
- [x] `mdsmith check .` (585 files, 0 failures)
- [x] `mdsmith fix .` (catalogs refreshed, e.g. `PLAN.md`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SjmEMykMXzY1Tcy7oy2QbY)_