### PR TITLE
perf: five hot-path fixes from a high-performance-go audit

### DIFF
--- a/internal/rules/MDS060-occurrence/bad/nested-sections.md
+++ b/internal/rules/MDS060-occurrence/bad/nested-sections.md
@@ -1,0 +1,29 @@
+---
+settings:
+  tokens:
+    - process
+  scope: section
+  count: each
+  max: 3
+diagnostics:
+  - line: 1
+    column: 1
+    message: '"process" appears 8 time(s) in section (max 3)'
+  - line: 5
+    column: 1
+    message: '"process" appears 4 time(s) in section (max 3)'
+  - line: 9
+    column: 1
+    message: '"process" appears 4 time(s) in section (max 3)'
+---
+# A
+
+process process process process.
+
+## B
+
+process process process process.
+
+# C
+
+process process process process.

--- a/internal/rules/MDS075-over-repetition/bad/nested-sections.md
+++ b/internal/rules/MDS075-over-repetition/bad/nested-sections.md
@@ -1,0 +1,27 @@
+---
+settings:
+  scope: section
+  max: 3
+  min-length: 4
+diagnostics:
+  - line: 1
+    column: 1
+    message: '"process" repeated 8 time(s) in section (max 3)'
+  - line: 5
+    column: 1
+    message: '"process" repeated 4 time(s) in section (max 3)'
+  - line: 9
+    column: 1
+    message: '"process" repeated 4 time(s) in section (max 3)'
+---
+# A
+
+process process process process.
+
+## B
+
+process process process process.
+
+# C
+
+process process process process.

--- a/internal/rules/astutil/astutil.go
+++ b/internal/rules/astutil/astutil.go
@@ -374,9 +374,7 @@ func SectionBodies(headings []SectionHeading, paragraphs []SectionParagraph, sou
 	for i := range headings {
 		start := headings[i].Line
 		end := SectionEnd(headings, i, totalLines)
-		for lo < len(paragraphs) && paragraphs[lo].Line < start {
-			lo++
-		}
+		lo = AdvancePastLine(paragraphs, lo, start)
 		parts = parts[:0]
 		for j := lo; j < len(paragraphs) && paragraphs[j].Line < end; j++ {
 			parts = append(parts, paragraphs[j].ExtractText(source))
@@ -396,16 +394,18 @@ func SectionBodies(headings []SectionHeading, paragraphs []SectionParagraph, sou
 // Line below start, hence below every later, higher-or-equal start
 // too, so it can never be needed by a later call in such a sequence.
 //
-// Unlike SectionBody/SectionBodies, this only advances past the
-// skipped prefix — it does not also advance past the paragraphs a
-// caller goes on to collect from the returned index onward. A
-// hierarchical section model (see SectionEnd) lets a later, deeper
-// heading's window overlap an earlier, shallower one's, so those
-// paragraphs may need to be collected again by a later call; a caller
-// whose windows form a true non-overlapping partition (not
-// SectionEnd's) may still choose to advance its own cursor past its
-// collected range, since AdvancePastLine only handles the shared skip
-// half of that trade-off.
+// This only advances past the skipped prefix — it does not also
+// advance past the paragraphs a caller goes on to collect from the
+// returned index onward, unlike SectionBody's binary search (which
+// looks up both ends of its range independently and has no cursor to
+// share). A hierarchical section model (see SectionEnd) lets a later,
+// deeper heading's window overlap an earlier, shallower one's, so
+// those paragraphs may need to be collected again by a later call, as
+// SectionBodies (which shares this helper) relies on; a caller whose
+// windows form a true non-overlapping partition (not SectionEnd's)
+// may still choose to advance its own cursor past its collected
+// range, since AdvancePastLine only handles the shared skip half of
+// that trade-off.
 func AdvancePastLine(paragraphs []SectionParagraph, lo, start int) int {
 	for lo < len(paragraphs) && paragraphs[lo].Line < start {
 		lo++

--- a/internal/rules/astutil/astutil.go
+++ b/internal/rules/astutil/astutil.go
@@ -386,6 +386,33 @@ func SectionBodies(headings []SectionHeading, paragraphs []SectionParagraph, sou
 	return bodies
 }
 
+// AdvancePastLine returns the first index at or after lo whose entry's
+// Line is not less than start. paragraphs must be in ascending Line
+// order.
+//
+// Safe to thread lo across a sequence of calls with non-decreasing
+// start values over the same paragraphs slice (as a per-heading loop
+// over ascending headings does): a paragraph this call skips has a
+// Line below start, hence below every later, higher-or-equal start
+// too, so it can never be needed by a later call in such a sequence.
+//
+// Unlike SectionBody/SectionBodies, this only advances past the
+// skipped prefix — it does not also advance past the paragraphs a
+// caller goes on to collect from the returned index onward. A
+// hierarchical section model (see SectionEnd) lets a later, deeper
+// heading's window overlap an earlier, shallower one's, so those
+// paragraphs may need to be collected again by a later call; a caller
+// whose windows form a true non-overlapping partition (not
+// SectionEnd's) may still choose to advance its own cursor past its
+// collected range, since AdvancePastLine only handles the shared skip
+// half of that trade-off.
+func AdvancePastLine(paragraphs []SectionParagraph, lo, start int) int {
+	for lo < len(paragraphs) && paragraphs[lo].Line < start {
+		lo++
+	}
+	return lo
+}
+
 // HeadingLine returns the 1-based source line of a heading node.
 // Setext headings expose their line via Lines(); ATX headings are found
 // by walking inline descendants until the first text segment. Returns 1

--- a/internal/rules/maxsectionlength/countsection_bench_test.go
+++ b/internal/rules/maxsectionlength/countsection_bench_test.go
@@ -1,0 +1,28 @@
+package maxsectionlength
+
+import (
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+)
+
+// BenchmarkCheck_ManySections pins docs/development/high-performance-go.md's
+// "Skip work you don't need" guideline: countSection used to rescan the
+// *entire* paragraphs slice from index 0 for every heading, making
+// Check's per-heading loop O(headings * paragraphs) instead of
+// O(headings + paragraphs). This benchmark's n scales both headings and
+// paragraphs together, so the quadratic term dominates unless the
+// forward-cursor fix is in place.
+func BenchmarkCheck_ManySections(b *testing.B) {
+	f, err := lint.NewFile("test.md", []byte(manySectionsDoc(600)))
+	if err != nil {
+		b.Fatal(err)
+	}
+	r := &Rule{MaxWords: 1000, MaxParagraphs: 1000}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = r.Check(f)
+	}
+}

--- a/internal/rules/maxsectionlength/rule.go
+++ b/internal/rules/maxsectionlength/rule.go
@@ -106,13 +106,25 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 	}
 
 	var diags []lint.Diagnostic
+	// paragraphPos is a forward-only cursor into paragraphs, shared
+	// across every heading's window. Heading windows are contiguous,
+	// non-overlapping, and ascending (headings and paragraphs are both
+	// in source-line order), so a paragraph consumed — or skipped as
+	// belonging to an earlier window — by one heading can never be
+	// needed by a later one. Threading the cursor through turns the
+	// whole loop into a single O(headings + paragraphs) pass instead of
+	// re-scanning all of paragraphs from index 0 per heading. See
+	// docs/development/high-performance-go.md's "Skip work you don't
+	// need" — the same forward-cursor pattern astutil.SectionBodies
+	// already uses for MDS057/MDS058.
+	paragraphPos := 0
 	for i, h := range headings {
 		end := totalLines
 		if i+1 < len(headings) {
 			end = headings[i+1].line - 1
 		}
 		diags = append(diags, r.checkLineLimit(f, h, end)...)
-		diags = append(diags, r.checkWordAndParagraphLimits(f, h, end, paragraphs)...)
+		diags = append(diags, r.checkWordAndParagraphLimits(f, h, end, paragraphs, &paragraphPos)...)
 	}
 	return diags
 }
@@ -138,12 +150,12 @@ func (r *Rule) checkLineLimit(f *lint.File, h heading, end int) []lint.Diagnosti
 }
 
 func (r *Rule) checkWordAndParagraphLimits(
-	f *lint.File, h heading, end int, paragraphs []paragraph,
+	f *lint.File, h heading, end int, paragraphs []paragraph, paragraphPos *int,
 ) []lint.Diagnostic {
 	if r.MaxWords <= 0 && r.MinWords <= 0 && r.MaxParagraphs <= 0 {
 		return nil
 	}
-	words, paraCount := countSection(paragraphs, h.line, end)
+	words, paraCount := countSection(paragraphs, paragraphPos, h.line, end)
 	var diags []lint.Diagnostic
 	if r.MaxWords > 0 && words > r.MaxWords {
 		diags = append(diags, lint.Diagnostic{
@@ -349,14 +361,27 @@ func collectParagraphs(f *lint.File) []paragraph {
 
 // countSection sums words and paragraphs for paragraphs whose start
 // line falls within [start, end].
-func countSection(paragraphs []paragraph, start, end int) (words, count int) {
-	for _, p := range paragraphs {
-		if p.line < start || p.line > end {
-			continue
-		}
-		words += p.words
-		count++
+// countSection sums the words and paragraph count of every entry in
+// paragraphs whose line falls in [start, end]. paragraphs must be in
+// ascending line order (astutil.CollectSectionParagraphs guarantees
+// this). *pos is a forward-only cursor: callers processing a sequence
+// of non-overlapping, ascending [start, end] windows over the same
+// paragraphs slice (as Check's per-heading loop does) should thread
+// the same pos through every call, since a paragraph this call skips
+// or consumes can never belong to a later, higher-numbered window —
+// letting the whole sequence of calls run in O(len(paragraphs)) total
+// instead of O(len(headings) * len(paragraphs)).
+func countSection(paragraphs []paragraph, pos *int, start, end int) (words, count int) {
+	for *pos < len(paragraphs) && paragraphs[*pos].line < start {
+		*pos++
 	}
+	i := *pos
+	for i < len(paragraphs) && paragraphs[i].line <= end {
+		words += paragraphs[i].words
+		count++
+		i++
+	}
+	*pos = i
 	return words, count
 }
 

--- a/internal/rules/maxsectionlength/rule.go
+++ b/internal/rules/maxsectionlength/rule.go
@@ -359,8 +359,6 @@ func collectParagraphs(f *lint.File) []paragraph {
 	return out
 }
 
-// countSection sums words and paragraphs for paragraphs whose start
-// line falls within [start, end].
 // countSection sums the words and paragraph count of every entry in
 // paragraphs whose line falls in [start, end]. paragraphs must be in
 // ascending line order (astutil.CollectSectionParagraphs guarantees

--- a/internal/rules/maxsectionlength/rule_test.go
+++ b/internal/rules/maxsectionlength/rule_test.go
@@ -20,6 +20,28 @@ func mustFile(t *testing.T, src string) *lint.File {
 	return f
 }
 
+// TestCountSection_SkipsPrecedingParagraphs exercises countSection's
+// pos-advance loop directly: a paragraph strictly before the window's
+// start must be skipped (not counted), and the cursor must carry
+// forward correctly into a second call for a later, higher window —
+// the shape Check's per-heading loop drives it with.
+func TestCountSection_SkipsPrecedingParagraphs(t *testing.T) {
+	paragraphs := []paragraph{
+		{line: 2, words: 3}, // preceding paragraph, must be skipped for [5, 10]
+		{line: 6, words: 4},
+		{line: 12, words: 5},
+	}
+	var pos int
+
+	words, count := countSection(paragraphs, &pos, 5, 10)
+	assert.Equal(t, 4, words, "only the line-6 paragraph falls in [5, 10]")
+	assert.Equal(t, 1, count)
+
+	words, count = countSection(paragraphs, &pos, 11, 20)
+	assert.Equal(t, 5, words, "cursor must still reach the line-12 paragraph")
+	assert.Equal(t, 1, count)
+}
+
 func TestCheck_NoHeadings_NoDiagnostic(t *testing.T) {
 	f := mustFile(t, "just some text\nand more\n")
 	r := &Rule{Max: 5}

--- a/internal/rules/noundefinedreferencelabels/nextbracket_bench_test.go
+++ b/internal/rules/noundefinedreferencelabels/nextbracket_bench_test.go
@@ -1,0 +1,37 @@
+package noundefinedreferencelabels
+
+import (
+	"strings"
+	"testing"
+)
+
+// proseWithoutBrackets builds n lines of ordinary prose containing no
+// '[' at all — the worst case for nextBracket's forward scan, since
+// every byte in the file must be inspected before the scanner can
+// report EOF.
+func proseWithoutBrackets(lines int) []byte {
+	var b strings.Builder
+	for i := 0; i < lines; i++ {
+		b.WriteString("The quick brown fox jumps over the lazy dog again and again.\n")
+	}
+	return []byte(b.String())
+}
+
+// BenchmarkNextBracket_NoBrackets pins the doc's "bytes.IndexByte over
+// a hand-rolled byte loop" guideline
+// (docs/development/high-performance-go.md#strings-and-bytes):
+// collectBrackets calls nextBracket to scan the *entire* file source
+// once, byte by byte, looking for '['. On a file with no reference-style
+// links at all (the common case — most files don't use them) the loop
+// must inspect every byte before reporting EOF, so this is exactly the
+// "big Source scan" case the guideline calls out as worth vectorizing.
+func BenchmarkNextBracket_NoBrackets(b *testing.B) {
+	source := proseWithoutBrackets(200)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _, _, _, ok := nextBracket(source, 0)
+		if ok {
+			b.Fatal("expected no bracket to be found")
+		}
+	}
+}

--- a/internal/rules/noundefinedreferencelabels/rule.go
+++ b/internal/rules/noundefinedreferencelabels/rule.go
@@ -245,11 +245,12 @@ func advanceBracket(brs []bracket, i, pos int) int {
 // task 7. Empty contents (`[]`) return contentStart == contentEnd;
 // the caller decides whether that is valid for the pattern.
 func nextBracket(source []byte, pos int) (open, contentStart, contentEnd, closeAfter int, ok bool) {
-	for pos < len(source) {
-		if source[pos] != '[' {
-			pos++
-			continue
+	for {
+		idx := bytes.IndexByte(source[pos:], '[')
+		if idx < 0 {
+			return 0, 0, 0, 0, false
 		}
+		pos += idx
 		open = pos
 		contentStart = pos + 1
 		i := contentStart
@@ -263,7 +264,6 @@ func nextBracket(source []byte, pos int) (open, contentStart, contentEnd, closeA
 		// advance past the orphan `[` and keep scanning.
 		pos++
 	}
-	return 0, 0, 0, 0, false
 }
 
 // scanFullRefs walks source for `[text][label]` patterns. The byte

--- a/internal/rules/occurrence/checksections_bench_test.go
+++ b/internal/rules/occurrence/checksections_bench_test.go
@@ -1,0 +1,39 @@
+package occurrence
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+)
+
+// manySectionsDoc builds a document with n level-2 headings, each
+// followed by one short paragraph — the shape that drives
+// checkSections's per-heading loop and, through it, the paragraph
+// range scans.
+func manySectionsDoc(n int) string {
+	var b strings.Builder
+	for i := 0; i < n; i++ {
+		b.WriteString("## Section\n\nA short paragraph with a foo token in it.\n\n")
+	}
+	return b.String()
+}
+
+// BenchmarkCheck_ManySections pins docs/development/high-performance-go.md's
+// "Skip work you don't need" guideline: checkSections's range helpers used
+// to rescan the *entire* paragraphs slice from index 0 for every heading,
+// making the section-scope Check O(headings * paragraphs) instead of
+// O(headings + paragraphs).
+func BenchmarkCheck_ManySections(b *testing.B) {
+	f, err := lint.NewFile("test.md", []byte(manySectionsDoc(600)))
+	if err != nil {
+		b.Fatal(err)
+	}
+	r := &Rule{Scope: "section", Count: "each", Tokens: []string{"foo"}, CaseSensitive: true}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = r.Check(f)
+	}
+}

--- a/internal/rules/occurrence/rule.go
+++ b/internal/rules/occurrence/rule.go
@@ -124,26 +124,31 @@ func (r *Rule) checkSections(f *lint.File) []lint.Diagnostic {
 		totalLines--
 	}
 	var diags []lint.Diagnostic
-	// combinedPos, tokensPos, and patternPos are forward-only cursors
+	// combinedLo, tokensLo, and patternLo are skip-ahead-only cursors
 	// into paragraphs, each threaded across the whole heading loop.
-	// Headings and paragraphs are both in ascending source-line order
-	// and each heading's [h.Line, end) window is non-overlapping with
-	// and after the previous one (astutil.SectionEnd is monotonic in
-	// i), so a paragraph one cursor skips or consumes can never be
-	// needed by that same cursor's later calls. This turns what would
-	// otherwise be an O(headings * paragraphs) rescan per active mode
-	// into O(headings + paragraphs) — see
+	// Headings are ascending, so a paragraph before headings[i].Line is
+	// also before every later heading's start — safe to skip for good,
+	// matching astutil.SectionBodies's lo cursor. None of them advance
+	// past the paragraphs a heading's own window collects: unlike
+	// maxsectionlength's flat, non-overlapping partition,
+	// astutil.SectionEnd's window for a shallow heading extends past
+	// its nested subsections, so a subsection's own iteration must
+	// still be able to collect paragraphs an ancestor heading's wider
+	// window already walked. This still turns the "skip the
+	// already-passed prefix" work into O(paragraphs) total per active
+	// mode instead of O(headings) rescans of it; the "collect this
+	// heading's window" work stays proportional to that section's own
+	// size, which is unavoidable for a hierarchical section model. See
 	// docs/development/high-performance-go.md's "Skip work you don't
-	// need", the same pattern maxsectionlength's countSection uses.
-	// combined/tokens/pattern never advance in the same Check call
-	// (r.Count picks exactly one branch), but each keeps its own
+	// need". combined/tokens/pattern never advance in the same Check
+	// call (r.Count picks exactly one branch), but each keeps its own
 	// cursor since a single heading's "each" branch can drive both the
 	// tokens loop and countPatternInRange over the same window.
-	var combinedPos, tokensPos, patternPos int
+	var combinedLo, tokensLo, patternLo int
 	for i, h := range headings {
 		end := astutil.SectionEnd(headings, i, totalLines)
 		if r.Count == "combined" {
-			combined := r.countCombinedInRange(paragraphs, f.Source, &combinedPos, h.Line, end)
+			combined := r.countCombinedInRange(paragraphs, f.Source, &combinedLo, h.Line, end)
 			diags = append(diags, r.diagCombined(combined, h.Line, "section", f.Path)...)
 		} else {
 			// "each" mode: iterate paragraphs once, pre-lowercasing text per
@@ -154,24 +159,21 @@ func (r *Rule) checkSections(f *lint.File) []lint.Diagnostic {
 			// for a loop that never runs.
 			if len(r.Tokens) > 0 {
 				totals := make([]int, len(r.Tokens))
-				for tokensPos < len(paragraphs) && paragraphs[tokensPos].Line < h.Line {
-					tokensPos++
+				for tokensLo < len(paragraphs) && paragraphs[tokensLo].Line < h.Line {
+					tokensLo++
 				}
-				j := tokensPos
-				for j < len(paragraphs) && paragraphs[j].Line < end {
+				for j := tokensLo; j < len(paragraphs) && paragraphs[j].Line < end; j++ {
 					stext := r.searchText(paragraphs[j].ExtractText(f.Source))
 					for ti := range r.Tokens {
 						totals[ti] += r.countToken(stext, ti)
 					}
-					j++
 				}
-				tokensPos = j
 				for ti, tok := range r.Tokens {
 					diags = append(diags, r.diagEach(totals[ti], h.Line, "section", tok, f.Path)...)
 				}
 			}
 			if r.Pattern != nil {
-				cnt := r.countPatternInRange(paragraphs, f.Source, &patternPos, h.Line, end)
+				cnt := r.countPatternInRange(paragraphs, f.Source, &patternLo, h.Line, end)
 				diags = append(diags, r.diagEach(cnt, h.Line, "section", r.patternSource, f.Path)...)
 			}
 		}
@@ -209,43 +211,41 @@ func (r *Rule) checkParagraphs(f *lint.File) []lint.Diagnostic {
 }
 
 // countCombinedInRange sums all match counts for paragraphs in
-// [start, end). paragraphs must be in ascending Line order; pos is a
-// forward-only cursor a caller threads across a sequence of
-// non-overlapping, ascending [start, end) windows over the same
-// paragraphs slice, so the whole sequence of calls runs in
-// O(len(paragraphs)) total instead of O(calls * len(paragraphs)). See
-// checkSections's cursor comment.
+// [start, end). paragraphs must be in ascending Line order; lo is a
+// skip-ahead-only cursor a caller threads across a sequence of
+// ascending-start windows over the same paragraphs slice (the windows
+// themselves may overlap, e.g. a shallow heading's window containing a
+// nested subsection's), so the "skip the already-passed prefix" work
+// runs in O(len(paragraphs)) total across the whole sequence of calls
+// instead of being repeated per call — see checkSections's cursor
+// comment. lo is deliberately NOT advanced past the paragraphs this
+// call collects: a later call in the sequence may need to collect
+// them again.
 func (r *Rule) countCombinedInRange(
-	paragraphs []astutil.SectionParagraph, source []byte, pos *int, start, end int,
+	paragraphs []astutil.SectionParagraph, source []byte, lo *int, start, end int,
 ) int {
-	for *pos < len(paragraphs) && paragraphs[*pos].Line < start {
-		*pos++
+	for *lo < len(paragraphs) && paragraphs[*lo].Line < start {
+		*lo++
 	}
 	total := 0
-	i := *pos
-	for i < len(paragraphs) && paragraphs[i].Line < end {
+	for i := *lo; i < len(paragraphs) && paragraphs[i].Line < end; i++ {
 		total += r.countCombined(paragraphs[i].ExtractText(source))
-		i++
 	}
-	*pos = i
 	return total
 }
 
 // countPatternInRange counts pattern matches for paragraphs in
-// [start, end). See countCombinedInRange for the pos cursor contract.
+// [start, end). See countCombinedInRange for the lo cursor contract.
 func (r *Rule) countPatternInRange(
-	paragraphs []astutil.SectionParagraph, source []byte, pos *int, start, end int,
+	paragraphs []astutil.SectionParagraph, source []byte, lo *int, start, end int,
 ) int {
-	for *pos < len(paragraphs) && paragraphs[*pos].Line < start {
-		*pos++
+	for *lo < len(paragraphs) && paragraphs[*lo].Line < start {
+		*lo++
 	}
 	total := 0
-	i := *pos
-	for i < len(paragraphs) && paragraphs[i].Line < end {
+	for i := *lo; i < len(paragraphs) && paragraphs[i].Line < end; i++ {
 		total += r.countPattern(paragraphs[i].ExtractText(source))
-		i++
 	}
-	*pos = i
 	return total
 }
 

--- a/internal/rules/occurrence/rule.go
+++ b/internal/rules/occurrence/rule.go
@@ -159,9 +159,7 @@ func (r *Rule) checkSections(f *lint.File) []lint.Diagnostic {
 			// for a loop that never runs.
 			if len(r.Tokens) > 0 {
 				totals := make([]int, len(r.Tokens))
-				for tokensLo < len(paragraphs) && paragraphs[tokensLo].Line < h.Line {
-					tokensLo++
-				}
+				tokensLo = astutil.AdvancePastLine(paragraphs, tokensLo, h.Line)
 				for j := tokensLo; j < len(paragraphs) && paragraphs[j].Line < end; j++ {
 					stext := r.searchText(paragraphs[j].ExtractText(f.Source))
 					for ti := range r.Tokens {
@@ -224,9 +222,7 @@ func (r *Rule) checkParagraphs(f *lint.File) []lint.Diagnostic {
 func (r *Rule) countCombinedInRange(
 	paragraphs []astutil.SectionParagraph, source []byte, lo *int, start, end int,
 ) int {
-	for *lo < len(paragraphs) && paragraphs[*lo].Line < start {
-		*lo++
-	}
+	*lo = astutil.AdvancePastLine(paragraphs, *lo, start)
 	total := 0
 	for i := *lo; i < len(paragraphs) && paragraphs[i].Line < end; i++ {
 		total += r.countCombined(paragraphs[i].ExtractText(source))
@@ -239,9 +235,7 @@ func (r *Rule) countCombinedInRange(
 func (r *Rule) countPatternInRange(
 	paragraphs []astutil.SectionParagraph, source []byte, lo *int, start, end int,
 ) int {
-	for *lo < len(paragraphs) && paragraphs[*lo].Line < start {
-		*lo++
-	}
+	*lo = astutil.AdvancePastLine(paragraphs, *lo, start)
 	total := 0
 	for i := *lo; i < len(paragraphs) && paragraphs[i].Line < end; i++ {
 		total += r.countPattern(paragraphs[i].ExtractText(source))

--- a/internal/rules/occurrence/rule.go
+++ b/internal/rules/occurrence/rule.go
@@ -124,10 +124,26 @@ func (r *Rule) checkSections(f *lint.File) []lint.Diagnostic {
 		totalLines--
 	}
 	var diags []lint.Diagnostic
+	// combinedPos, tokensPos, and patternPos are forward-only cursors
+	// into paragraphs, each threaded across the whole heading loop.
+	// Headings and paragraphs are both in ascending source-line order
+	// and each heading's [h.Line, end) window is non-overlapping with
+	// and after the previous one (astutil.SectionEnd is monotonic in
+	// i), so a paragraph one cursor skips or consumes can never be
+	// needed by that same cursor's later calls. This turns what would
+	// otherwise be an O(headings * paragraphs) rescan per active mode
+	// into O(headings + paragraphs) — see
+	// docs/development/high-performance-go.md's "Skip work you don't
+	// need", the same pattern maxsectionlength's countSection uses.
+	// combined/tokens/pattern never advance in the same Check call
+	// (r.Count picks exactly one branch), but each keeps its own
+	// cursor since a single heading's "each" branch can drive both the
+	// tokens loop and countPatternInRange over the same window.
+	var combinedPos, tokensPos, patternPos int
 	for i, h := range headings {
 		end := astutil.SectionEnd(headings, i, totalLines)
 		if r.Count == "combined" {
-			combined := r.countCombinedInRange(paragraphs, f.Source, h.Line, end)
+			combined := r.countCombinedInRange(paragraphs, f.Source, &combinedPos, h.Line, end)
 			diags = append(diags, r.diagCombined(combined, h.Line, "section", f.Path)...)
 		} else {
 			// "each" mode: iterate paragraphs once, pre-lowercasing text per
@@ -138,21 +154,24 @@ func (r *Rule) checkSections(f *lint.File) []lint.Diagnostic {
 			// for a loop that never runs.
 			if len(r.Tokens) > 0 {
 				totals := make([]int, len(r.Tokens))
-				for j := range paragraphs {
-					if paragraphs[j].Line < h.Line || paragraphs[j].Line >= end {
-						continue
-					}
+				for tokensPos < len(paragraphs) && paragraphs[tokensPos].Line < h.Line {
+					tokensPos++
+				}
+				j := tokensPos
+				for j < len(paragraphs) && paragraphs[j].Line < end {
 					stext := r.searchText(paragraphs[j].ExtractText(f.Source))
 					for ti := range r.Tokens {
 						totals[ti] += r.countToken(stext, ti)
 					}
+					j++
 				}
+				tokensPos = j
 				for ti, tok := range r.Tokens {
 					diags = append(diags, r.diagEach(totals[ti], h.Line, "section", tok, f.Path)...)
 				}
 			}
 			if r.Pattern != nil {
-				cnt := r.countPatternInRange(paragraphs, f.Source, h.Line, end)
+				cnt := r.countPatternInRange(paragraphs, f.Source, &patternPos, h.Line, end)
 				diags = append(diags, r.diagEach(cnt, h.Line, "section", r.patternSource, f.Path)...)
 			}
 		}
@@ -189,27 +208,44 @@ func (r *Rule) checkParagraphs(f *lint.File) []lint.Diagnostic {
 	return diags
 }
 
-// countCombinedInRange sums all match counts for paragraphs in [start, end).
-func (r *Rule) countCombinedInRange(paragraphs []astutil.SectionParagraph, source []byte, start, end int) int {
-	total := 0
-	for i := range paragraphs {
-		if paragraphs[i].Line < start || paragraphs[i].Line >= end {
-			continue
-		}
-		total += r.countCombined(paragraphs[i].ExtractText(source))
+// countCombinedInRange sums all match counts for paragraphs in
+// [start, end). paragraphs must be in ascending Line order; pos is a
+// forward-only cursor a caller threads across a sequence of
+// non-overlapping, ascending [start, end) windows over the same
+// paragraphs slice, so the whole sequence of calls runs in
+// O(len(paragraphs)) total instead of O(calls * len(paragraphs)). See
+// checkSections's cursor comment.
+func (r *Rule) countCombinedInRange(
+	paragraphs []astutil.SectionParagraph, source []byte, pos *int, start, end int,
+) int {
+	for *pos < len(paragraphs) && paragraphs[*pos].Line < start {
+		*pos++
 	}
+	total := 0
+	i := *pos
+	for i < len(paragraphs) && paragraphs[i].Line < end {
+		total += r.countCombined(paragraphs[i].ExtractText(source))
+		i++
+	}
+	*pos = i
 	return total
 }
 
-// countPatternInRange counts pattern matches for paragraphs in [start, end).
-func (r *Rule) countPatternInRange(paragraphs []astutil.SectionParagraph, source []byte, start, end int) int {
-	total := 0
-	for i := range paragraphs {
-		if paragraphs[i].Line < start || paragraphs[i].Line >= end {
-			continue
-		}
-		total += r.countPattern(paragraphs[i].ExtractText(source))
+// countPatternInRange counts pattern matches for paragraphs in
+// [start, end). See countCombinedInRange for the pos cursor contract.
+func (r *Rule) countPatternInRange(
+	paragraphs []astutil.SectionParagraph, source []byte, pos *int, start, end int,
+) int {
+	for *pos < len(paragraphs) && paragraphs[*pos].Line < start {
+		*pos++
 	}
+	total := 0
+	i := *pos
+	for i < len(paragraphs) && paragraphs[i].Line < end {
+		total += r.countPattern(paragraphs[i].ExtractText(source))
+		i++
+	}
+	*pos = i
 	return total
 }
 

--- a/internal/rules/occurrence/rule_test.go
+++ b/internal/rules/occurrence/rule_test.go
@@ -435,15 +435,21 @@ func TestCheck_Section_PatternMultipleHeadings(t *testing.T) {
 
 func TestCountCombinedInRange(t *testing.T) {
 	r := &Rule{Tokens: []string{"foo"}, CaseSensitive: true}
+	// Ascending Line order: countCombinedInRange's pos cursor only
+	// moves forward, matching the guarantee astutil.CollectSectionParagraphs
+	// (production's source for this slice) documents.
 	paragraphs := []astutil.SectionParagraph{
 		{Text: "foo foo", Line: 2},
-		{Text: "bar", Line: 10},
 		{Text: "foo", Line: 3},
+		{Text: "bar", Line: 10},
 	}
+	var pos int
 	// [2, 5) covers lines 2 and 3: 2+1 = 3 matches
-	assert.Equal(t, 3, r.countCombinedInRange(paragraphs, nil, 2, 5))
-	// [10, 11) covers line 10: no "foo"
-	assert.Equal(t, 0, r.countCombinedInRange(paragraphs, nil, 10, 11))
+	assert.Equal(t, 3, r.countCombinedInRange(paragraphs, nil, &pos, 2, 5))
+	// [10, 11) covers line 10: no "foo". Reuses the same cursor,
+	// mirroring how checkSections threads one cursor across a
+	// sequence of ascending, non-overlapping windows.
+	assert.Equal(t, 0, r.countCombinedInRange(paragraphs, nil, &pos, 10, 11))
 }
 
 func TestCountPatternInRange(t *testing.T) {
@@ -453,8 +459,9 @@ func TestCountPatternInRange(t *testing.T) {
 		{Text: "foo bar foo", Line: 2},
 		{Text: "baz", Line: 10},
 	}
-	assert.Equal(t, 2, r.countPatternInRange(paragraphs, nil, 2, 5))
-	assert.Equal(t, 0, r.countPatternInRange(paragraphs, nil, 5, 9))
+	var pos int
+	assert.Equal(t, 2, r.countPatternInRange(paragraphs, nil, &pos, 2, 5))
+	assert.Equal(t, 0, r.countPatternInRange(paragraphs, nil, &pos, 5, 9))
 }
 
 func TestCountCombined(t *testing.T) {

--- a/internal/rules/occurrence/rule_test.go
+++ b/internal/rules/occurrence/rule_test.go
@@ -431,6 +431,32 @@ func TestCheck_Section_PatternMultipleHeadings(t *testing.T) {
 	assert.Equal(t, 1, diags[0].Line)
 }
 
+// TestCheck_Section_NestedHeadingViolatesIndependently pins the
+// hierarchical section-window contract astutil.SectionEnd defines: a
+// shallow heading's window extends through its nested subsections (so
+// its own count legitimately includes their content), but each nested
+// subsection must still be checked, and flagged, independently against
+// its own narrower window. A cursor optimization that permanently
+// consumes paragraphs once one heading's wider window has scanned them
+// would silently lose every nested subsection's own violation — this
+// was exactly the shape of a regression caught in review. Three
+// headings (level 1, 2, 1) each carry their own violating count, so
+// all three must be reported.
+func TestCheck_Section_NestedHeadingViolatesIndependently(t *testing.T) {
+	r := &Rule{}
+	mustApply(t, r, map[string]any{
+		"tokens": []any{"process"}, "max": 3, "scope": "section", "count": "each",
+	})
+	src := "# A\n\nprocess process process process.\n\n" +
+		"## B\n\nprocess process process process.\n\n" +
+		"# C\n\nprocess process process process.\n"
+	diags := r.Check(mustFile(t, src))
+	require.Len(t, diags, 3, "expected a violation for A, B, and C independently: %+v", diags)
+	assert.Equal(t, 1, diags[0].Line, "section A")
+	assert.Equal(t, 5, diags[1].Line, "section B")
+	assert.Equal(t, 9, diags[2].Line, "section C")
+}
+
 // --- private helper unit tests ---
 
 func TestCountCombinedInRange(t *testing.T) {

--- a/internal/rules/overrepetition/checksections_bench_test.go
+++ b/internal/rules/overrepetition/checksections_bench_test.go
@@ -1,0 +1,38 @@
+package overrepetition
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+)
+
+// manySectionsDoc builds a document with n level-2 headings, each
+// followed by one short paragraph — the shape that drives
+// checkSections's per-heading loop and its paragraph-range scan.
+func manySectionsDoc(n int) string {
+	var b strings.Builder
+	for i := 0; i < n; i++ {
+		b.WriteString("## Section\n\nA short paragraph with a few distinct words in it.\n\n")
+	}
+	return b.String()
+}
+
+// BenchmarkCheck_ManySections pins docs/development/high-performance-go.md's
+// "Skip work you don't need" guideline: checkSections used to rescan the
+// *entire* paragraphs slice from index 0 for every heading, making the
+// section-scope Check O(headings * paragraphs) instead of
+// O(headings + paragraphs).
+func BenchmarkCheck_ManySections(b *testing.B) {
+	f, err := lint.NewFile("test.md", []byte(manySectionsDoc(600)))
+	if err != nil {
+		b.Fatal(err)
+	}
+	r := &Rule{Scope: "section", Max: 1000}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = r.Check(f)
+	}
+}

--- a/internal/rules/overrepetition/rule.go
+++ b/internal/rules/overrepetition/rule.go
@@ -91,25 +91,35 @@ func (r *Rule) checkSections(f *lint.File) []lint.Diagnostic {
 
 	freq := make(map[string]int, 32) // 32 covers typical prose vocabulary per section
 
-	// pos is a forward-only cursor into paragraphs, shared by the
-	// preamble scan below and the per-heading loop that follows.
-	// paragraphs and headings are both in ascending source-line order
-	// and each heading's [h.Line, end) window is non-overlapping with
-	// and after the previous one (astutil.SectionEnd is monotonic in
-	// i), so a paragraph pos has already skipped or consumed can never
-	// be needed again. This turns the whole pass into
-	// O(headings + paragraphs) instead of re-scanning all of
-	// paragraphs from index 0 per section — see
+	// lo is a skip-ahead-only cursor into paragraphs, shared by the
+	// preamble scan below and the per-heading loop that follows. It
+	// only ever advances past a paragraph once that paragraph's line
+	// is known to be before every remaining heading's start (headings
+	// are ascending, so a paragraph before headings[i].Line is also
+	// before headings[i+1].Line, headings[i+2].Line, ...) — matching
+	// astutil.SectionBodies's lo cursor. Crucially, lo is NOT advanced
+	// past the paragraphs a heading's own window collects: unlike
+	// maxsectionlength's flat, non-overlapping partition,
+	// astutil.SectionEnd's window for a shallow heading extends past
+	// its nested subsections, so a subsection's own iteration must
+	// still be able to collect paragraphs an ancestor heading's wider
+	// window already walked. This still turns the "skip the already-
+	// passed prefix" work into O(paragraphs) total instead of
+	// O(headings) rescans of it; the "collect this heading's window"
+	// work stays proportional to that section's own size, which is
+	// unavoidable for a hierarchical section model. See
 	// docs/development/high-performance-go.md's "Skip work you don't
-	// need", the same pattern maxsectionlength's countSection uses.
-	pos := 0
+	// need".
+	lo := 0
 
 	// Check preamble paragraphs (before the first heading) as one implicit section.
 	// Skip the allocation when no preamble paragraphs exist (the common case).
+	// Preamble paragraphs precede every heading, so unlike the per-heading
+	// window below, lo can safely advance past them for good.
 	firstHeadingLine := headings[0].Line
-	for pos < len(paragraphs) && paragraphs[pos].Line < firstHeadingLine {
-		r.accum(freq, paragraphs[pos].ExtractText(f.Source))
-		pos++
+	for lo < len(paragraphs) && paragraphs[lo].Line < firstHeadingLine {
+		r.accum(freq, paragraphs[lo].ExtractText(f.Source))
+		lo++
 	}
 	var diags []lint.Diagnostic
 	if len(freq) > 0 {
@@ -120,12 +130,11 @@ func (r *Rule) checkSections(f *lint.File) []lint.Diagnostic {
 	for i, h := range headings {
 		end := astutil.SectionEnd(headings, i, totalLines)
 		clear(freq)
-		for pos < len(paragraphs) && paragraphs[pos].Line < h.Line {
-			pos++
+		for lo < len(paragraphs) && paragraphs[lo].Line < h.Line {
+			lo++
 		}
-		for pos < len(paragraphs) && paragraphs[pos].Line < end {
-			r.accum(freq, paragraphs[pos].ExtractText(f.Source))
-			pos++
+		for j := lo; j < len(paragraphs) && paragraphs[j].Line < end; j++ {
+			r.accum(freq, paragraphs[j].ExtractText(f.Source))
 		}
 		r.removeStopwords(freq)
 		diags = append(diags, r.diagFromFreq(freq, h.Line, "section", f.Path)...)

--- a/internal/rules/overrepetition/rule.go
+++ b/internal/rules/overrepetition/rule.go
@@ -91,13 +91,25 @@ func (r *Rule) checkSections(f *lint.File) []lint.Diagnostic {
 
 	freq := make(map[string]int, 32) // 32 covers typical prose vocabulary per section
 
+	// pos is a forward-only cursor into paragraphs, shared by the
+	// preamble scan below and the per-heading loop that follows.
+	// paragraphs and headings are both in ascending source-line order
+	// and each heading's [h.Line, end) window is non-overlapping with
+	// and after the previous one (astutil.SectionEnd is monotonic in
+	// i), so a paragraph pos has already skipped or consumed can never
+	// be needed again. This turns the whole pass into
+	// O(headings + paragraphs) instead of re-scanning all of
+	// paragraphs from index 0 per section — see
+	// docs/development/high-performance-go.md's "Skip work you don't
+	// need", the same pattern maxsectionlength's countSection uses.
+	pos := 0
+
 	// Check preamble paragraphs (before the first heading) as one implicit section.
 	// Skip the allocation when no preamble paragraphs exist (the common case).
 	firstHeadingLine := headings[0].Line
-	for j := range paragraphs {
-		if paragraphs[j].Line < firstHeadingLine {
-			r.accum(freq, paragraphs[j].ExtractText(f.Source))
-		}
+	for pos < len(paragraphs) && paragraphs[pos].Line < firstHeadingLine {
+		r.accum(freq, paragraphs[pos].ExtractText(f.Source))
+		pos++
 	}
 	var diags []lint.Diagnostic
 	if len(freq) > 0 {
@@ -108,11 +120,12 @@ func (r *Rule) checkSections(f *lint.File) []lint.Diagnostic {
 	for i, h := range headings {
 		end := astutil.SectionEnd(headings, i, totalLines)
 		clear(freq)
-		for j := range paragraphs {
-			if paragraphs[j].Line < h.Line || paragraphs[j].Line >= end {
-				continue
-			}
-			r.accum(freq, paragraphs[j].ExtractText(f.Source))
+		for pos < len(paragraphs) && paragraphs[pos].Line < h.Line {
+			pos++
+		}
+		for pos < len(paragraphs) && paragraphs[pos].Line < end {
+			r.accum(freq, paragraphs[pos].ExtractText(f.Source))
+			pos++
 		}
 		r.removeStopwords(freq)
 		diags = append(diags, r.diagFromFreq(freq, h.Line, "section", f.Path)...)

--- a/internal/rules/overrepetition/rule.go
+++ b/internal/rules/overrepetition/rule.go
@@ -130,9 +130,7 @@ func (r *Rule) checkSections(f *lint.File) []lint.Diagnostic {
 	for i, h := range headings {
 		end := astutil.SectionEnd(headings, i, totalLines)
 		clear(freq)
-		for lo < len(paragraphs) && paragraphs[lo].Line < h.Line {
-			lo++
-		}
+		lo = astutil.AdvancePastLine(paragraphs, lo, h.Line)
 		for j := lo; j < len(paragraphs) && paragraphs[j].Line < end; j++ {
 			r.accum(freq, paragraphs[j].ExtractText(f.Source))
 		}

--- a/internal/rules/overrepetition/rule_test.go
+++ b/internal/rules/overrepetition/rule_test.go
@@ -117,6 +117,30 @@ func TestCheck_Section_PreambleCounted(t *testing.T) {
 	assert.Contains(t, diags[0].Message, "process")
 }
 
+// TestCheck_Section_NestedHeadingViolatesIndependently pins the
+// hierarchical section-window contract astutil.SectionEnd defines: a
+// shallow heading's window extends through its nested subsections (so
+// its own word-frequency count legitimately includes their content),
+// but each nested subsection must still be checked, and flagged,
+// independently against its own narrower window. A cursor optimization
+// that permanently consumes paragraphs once one heading's wider window
+// has scanned them would silently lose every nested subsection's own
+// violation — this was exactly the shape of a regression caught in
+// review. Three headings (level 1, 2, 1) each carry their own
+// violating word, so all three must be reported.
+func TestCheck_Section_NestedHeadingViolatesIndependently(t *testing.T) {
+	r := &Rule{}
+	mustApply(t, r, map[string]any{"scope": "section", "max": 3, "min-length": 4})
+	src := "# A\n\nprocess process process process.\n\n" +
+		"## B\n\nprocess process process process.\n\n" +
+		"# C\n\nprocess process process process.\n"
+	diags := r.Check(mustFile(t, src))
+	require.Len(t, diags, 3, "expected a violation for A, B, and C independently: %+v", diags)
+	assert.Equal(t, 1, diags[0].Line, "section A")
+	assert.Equal(t, 5, diags[1].Line, "section B")
+	assert.Equal(t, 9, diags[2].Line, "section C")
+}
+
 // --- file scope ---
 
 func TestCheck_File_ExceedsMax_Diagnostic(t *testing.T) {

--- a/internal/rules/requiredstructure/rule.go
+++ b/internal/rules/requiredstructure/rule.go
@@ -1375,7 +1375,11 @@ func cueFieldLabel(key string) string {
 
 // collectBodySyncPoints scans body content for {field} references and
 // adds them to the syncPoints map under their nearest preceding heading.
-// Iterates over content bytes directly to avoid the bytes.Split allocation.
+// Splits lines via bytes.IndexByte rather than a hand-rolled byte-by-byte
+// scan or bytes.Split, so a line-heavy schema body pays one SIMD-accelerated
+// forward search per line instead of one branch per byte — see
+// docs/development/high-performance-go.md#strings-and-bytes — without
+// paying bytes.Split's up-front allocation of every line's slice header.
 // fieldCache is forwarded to appendBodySyncFields; see buildFieldPattern's
 // doc comment.
 func collectBodySyncPoints(
@@ -1393,13 +1397,14 @@ func collectBodySyncPoints(
 	var fenceChar byte
 	fenceLen := 0
 	start := 0
-	for i := 0; i <= len(content); i++ {
-		if i < len(content) && content[i] != '\n' {
-			continue
+	for start <= len(content) {
+		end := len(content)
+		if idx := bytes.IndexByte(content[start:], '\n'); idx >= 0 {
+			end = start + idx
 		}
-		raw := content[start:i]
+		raw := content[start:end]
 		lineB := bytes.TrimSpace(raw)
-		start = i + 1
+		start = end + 1
 		if len(lineB) == 0 {
 			continue
 		}

--- a/internal/rules/requiredstructure/syncpoints_bench_test.go
+++ b/internal/rules/requiredstructure/syncpoints_bench_test.go
@@ -1,0 +1,35 @@
+package requiredstructure
+
+import (
+	"strings"
+	"testing"
+)
+
+// proseBodyNoFields builds n lines of ordinary prose with no `#`
+// headings, no `{field}` references, and no fences or directives — the
+// worst case for collectBodySyncPoints's line scan, since every branch
+// after the newline search is a cheap no-op and the newline search
+// itself dominates.
+func proseBodyNoFields(lines int) []byte {
+	var b strings.Builder
+	for i := 0; i < lines; i++ {
+		b.WriteString("Ordinary prose line with no template syntax at all.\n")
+	}
+	return []byte(b.String())
+}
+
+// BenchmarkCollectBodySyncPoints_NoFields pins the doc's "bytes.IndexByte
+// over a hand-rolled byte loop" guideline
+// (docs/development/high-performance-go.md#strings-and-bytes):
+// collectBodySyncPoints scans the schema body's *entire* content once,
+// byte by byte, to split it into lines. A large schema with no `{field}`
+// text anywhere still pays that full scan.
+func BenchmarkCollectBodySyncPoints_NoFields(b *testing.B) {
+	content := proseBodyNoFields(200)
+	var headings []docHeading
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		syncPoints := make(map[int][]syncPoint)
+		collectBodySyncPoints(content, headings, syncPoints, nil)
+	}
+}

--- a/internal/rules/uniquefrontmatter/alloc_test.go
+++ b/internal/rules/uniquefrontmatter/alloc_test.go
@@ -31,8 +31,13 @@ func TestCheck_ConfiguredSteadyStateAllocs(t *testing.T) {
 	flagged.RunCache = rc
 	require.Len(t, r.Check(flagged), 1)
 
+	// 3, not the rule-wide ≤10 budget: fmt.Sprintf("... %q ...", ...) building
+	// the diagnostic message cost 2 extra allocations (the reflection-driven
+	// format scan plus its []byte result) that strconv.Quote plus string
+	// concatenation does not pay. See
+	// docs/development/high-performance-go.md#strings-and-bytes.
 	allocs = testing.AllocsPerRun(100, func() { _ = r.Check(flagged) })
-	assert.LessOrEqual(t, allocs, 10.0,
+	assert.LessOrEqual(t, allocs, 3.0,
 		"flagged in-scope file, warm index: %v allocs", allocs)
 }
 

--- a/internal/rules/uniquefrontmatter/rule.go
+++ b/internal/rules/uniquefrontmatter/rule.go
@@ -14,6 +14,7 @@ import (
 	"path"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
@@ -147,9 +148,8 @@ func (r *Rule) Check(f *lint.File) []lint.Diagnostic {
 		Column:   1,
 		RuleID:   r.ID(),
 		RuleName: r.Name(),
-		Message: fmt.Sprintf(
-			"front-matter %q: value %s already used by %s",
-			r.Field, e.value, e.firstPath),
+		Message: "front-matter " + strconv.Quote(r.Field) +
+			": value " + e.value + " already used by " + e.firstPath,
 	}}
 }
 


### PR DESCRIPTION
## Summary

An audit against `docs/development/high-performance-go.md` scanned `internal/rules`, the core engine/parser packages (`internal/engine`, `internal/lint`, `pkg/markdown`, `pkg/goldmark`), and the CLI/LSP/fix-loop surfaces for violations of the project's own performance guidelines. Every candidate was verified empirically — with `testing.AllocsPerRun`, `go test -bench` + `benchstat`, or a real CPU/memory profile of `BenchmarkCheckCorpusLarge` (the "Large gate" 600-file corpus) — before being fixed with red/green TDD.

Several plausible-looking candidates from static review were investigated and **ruled out** after measurement showed no real cost (see Notes below); this codebase turned out to already be unusually well-optimized, consistent with the project's own stated practice of profiling before rewriting. The top 5 issues that survived verification, ranked by severity:

1. **Algorithmic complexity: O(headings × paragraphs) section-scope rescans, in three rule packages** — `internal/rules/maxsectionlength` (MDS036), `internal/rules/occurrence` (MDS060), and `internal/rules/overrepetition` (MDS075) each drive a per-heading loop that calls a helper doing a *full linear rescan* of the whole paragraphs slice from index 0, even though both headings and paragraphs are guaranteed ascending by source line — the exact "skip work you don't need" anti-pattern the doc calls out, and the same forward-cursor pattern `astutil.SectionBodies` already uses for MDS057/MDS058. Threading a shared cursor through each rule's loop turns it from O(headings × paragraphs) into O(headings + paragraphs) for the redundant "skip the already-passed prefix" work:
   - `maxsectionlength`: 600-heading/600-paragraph benchmark ~335µs → ~148µs/op (**-55.9%**, p=0.008)
   - `occurrence`: same shape, ~662µs → ~405µs/op (**-38.9%**, p=0.008)
   - `overrepetition`: same shape, ~693µs → ~436µs/op (**-37.1%**, p=0.008)

   All three are allocation-neutral. **A code-review pass on the first cursor implementation for `occurrence`/`overrepetition` caught a real correctness regression** before merge: `astutil.SectionEnd`'s section windows are hierarchical (a shallow heading's window intentionally extends through its nested subsections), unlike `maxsectionlength`'s own flat, non-overlapping partition — a cursor that permanently consumes every paragraph it collects silently drops each nested subsection's own violation. Fixed by switching to the skip-ahead-only cursor shape `astutil.SectionBodies` already uses (only ever advances past paragraphs strictly *before* the current window, never past paragraphs the window collects), extracted as `astutil.AdvancePastLine` and shared across both rules and `SectionBodies` itself. Two new unit tests plus two new `internal/rules/MDS0##-.../bad/nested-sections.md` fixtures pin this with a 3-level nested-heading case, verified to fail against the reverted cursor and pass against the fix.
2. **`internal/rules/noundefinedreferencelabels` (MDS054, default-enabled)** — `nextBracket`'s bracket scan walked the entire file source byte-by-byte with a hand-rolled loop instead of `bytes.IndexByte`, the doc's "Strings and bytes" anti-pattern. Fixed with `bytes.IndexByte`: a 200-line no-bracket-match benchmark drops from ~5.8µs to ~0.2µs/op (**-96.6%**, p=0.008), zero allocation change.
3. **`internal/rules/requiredstructure` (MDS020, default-enabled)** — `collectBodySyncPoints` split the schema body into lines with the same hand-rolled byte-by-byte scan for `\n`. Fixed the same way: a 200-line no-`{field}` benchmark drops from ~11.5µs to ~4.6µs/op (**-60.3%**, p=0.008), zero allocation change.
4. **`internal/rules/uniquefrontmatter` (MDS069)** — the duplicate-value diagnostic message used `fmt.Sprintf("... %q ...", ...)`, the same reflection-driven pattern already fixed elsewhere in the rule set (`no-undefined-reference-labels`, `no-trailing-punctuation-in-heading`). Replaced with `strconv.Quote` + concatenation: the flagged-file path drops from 5 to 3 allocations/op, tightened in `TestCheck_ConfiguredSteadyStateAllocs`.

## Notes: candidates investigated and ruled out

Several audit leads looked promising from static review but did not survive measurement:

- **`internal/linkgraph`'s `ast.Walk` closures** (`ExtractLinks`, `ExtractImages`, `firstTextOffset`, etc.) and the same pattern in `internal/rules/samefileanchor` and `internal/rules/blockquotewhitespace` — `go build -gcflags="-m=2"` confirms the compiler already inlines this codebase's vendored `ast.Walk` and proves every one of these closures **does not escape**. There is no allocation to remove; converting them to hand-rolled recursion would be pure churn.
- **`internal/log.Logger.Printf`'s disabled-path argument boxing** — measured at **0 allocations** even with disabled logging and boxed `int`/`string` arguments; the compiler's escape analysis already eliminates it.
- **Large-struct-by-value parameters** (`schema.Scope` at 128 bytes in `internal/rules/requiredstructure/scope_rules.go`; `linkgraph.Link`/`Target` at 88/56 bytes in `internal/rules/crossfilereferenceintegrity`) — converting `walkScopes`/`runScopeRules` to pointer parameters showed **no statistically significant change** (`benchstat` p=0.151) on a 20-scope benchmark; the actual dominant costs in both rules (running a whole other rule's `Check`, and filesystem `Stat` calls) dwarf the parameter copy. Not pursued.
- **A cross-rule heading-text cache-sharing fix** in `internal/rules/noduplicateheadings` (using the already-existing `astutil.HeadingTextCached` instead of the raw `astutil.HeadingText`) showed a real, profile-verified win in the full corpus benchmark (eliminating a duplicate walk this rule shares with `no-trailing-punctuation-in-heading`), but it **regressed `internal/integration`'s per-rule allocation-budget gate** (9 → 11 allocs, ceiling 10): that gate measures each rule against a cold, single-use File, so it can only ever see the cache's write-side cost and never its cross-rule payoff. Reverted rather than bypass a real CI gate.

## Test plan

- [x] `go test ./...` — full suite passes
- [x] `go vet ./...` and `go tool -modfile=tools/go.mod golangci-lint run ./...` — clean, 0 issues
- [x] `go run ./cmd/mdsmith check .` — repo's own Markdown passes
- [x] `internal/integration` `TestPerRuleAllocBudget` — no regressions
- [x] Each perf fix red/green: a baseline benchmark before the change, a `benchstat`-significant improvement after (all comparisons at p=0.008, n=5)
- [x] Message-format parity preserved for the `uniquefrontmatter` diagnostic-text change (existing test pins the exact string)
- [x] Three independent `code-review` passes at `xhigh` severity — pass 1 caught and this branch fixed a real correctness regression in the `occurrence`/`overrepetition` cursor (with new unit + fixture tests proving it); passes 2 and 3 caught and fixed minor duplication/doc-comment cleanup; a final pass found no further issues
- [x] Existing behavioral test suites for every touched rule — including nested-section, preamble, and subsection-isolation fixtures — pass unchanged

Ref: `docs/development/high-performance-go.md`
