### PR TITLE
perf: fix top 5 high-performance-go violations (struct layout + allocations)

### DIFF
--- a/internal/rules/linkvalidity/layout_test.go
+++ b/internal/rules/linkvalidity/layout_test.go
@@ -1,0 +1,24 @@
+package linkvalidity
+
+import (
+	"testing"
+	"unsafe"
+)
+
+// TestRevMatchFieldOrder asserts that the pointer-containing text and
+// url byte slices precede the scalar col0 and matchEnd ints in
+// revMatch. Go's GC ptrdata for a struct spans from offset 0 through
+// the end of the last pointer-containing field; with the scalars
+// first (the prior order), ptrdata had to cover both slices anyway,
+// so grouping the slices first instead shrinks ptrdata from 48 bytes
+// to 32. See docs/development/high-performance-go.md "Struct
+// layout". The test fails (red) until col0 and matchEnd are moved
+// after text and url.
+func TestRevMatchFieldOrder(t *testing.T) {
+	got := unsafe.Offsetof(revMatch{}.col0)
+	const want = uintptr(48) // after text and url (24 bytes each)
+	if got != want {
+		t.Errorf("unsafe.Offsetof(revMatch.col0) = %d; want %d (move col0/matchEnd after text/url to minimise GC scan)",
+			got, want)
+	}
+}

--- a/internal/rules/linkvalidity/layout_test.go
+++ b/internal/rules/linkvalidity/layout_test.go
@@ -1,24 +1,21 @@
 package linkvalidity
 
 import (
+	"reflect"
 	"testing"
-	"unsafe"
+
+	"github.com/jeduden/mdsmith/internal/structlayout"
 )
 
-// TestRevMatchFieldOrder asserts that the pointer-containing text and
-// url byte slices precede the scalar col0 and matchEnd ints in
-// revMatch. Go's GC ptrdata for a struct spans from offset 0 through
-// the end of the last pointer-containing field; with the scalars
-// first (the prior order), ptrdata had to cover both slices anyway,
-// so grouping the slices first instead shrinks ptrdata from 48 bytes
-// to 32. See docs/development/high-performance-go.md "Struct
-// layout". The test fails (red) until col0 and matchEnd are moved
-// after text and url.
+// TestRevMatchFieldOrder guards the GC ptrdata region of revMatch:
+// the pointer-containing text and url byte slices must precede the
+// scalar col0 and matchEnd ints. Go's GC ptrdata for a struct spans
+// from offset 0 through the last pointer-containing field's pointer
+// word; with the scalars first (the prior order), ptrdata still had
+// to cover both slices, so grouping the slices first instead shrinks
+// ptrdata from 48 bytes to 32 on a 64-bit platform. See
+// docs/development/high-performance-go.md "Struct layout". The test
+// fails (red) until col0 and matchEnd are moved after text and url.
 func TestRevMatchFieldOrder(t *testing.T) {
-	got := unsafe.Offsetof(revMatch{}.col0)
-	const want = uintptr(48) // after text and url (24 bytes each)
-	if got != want {
-		t.Errorf("unsafe.Offsetof(revMatch.col0) = %d; want %d (move col0/matchEnd after text/url to minimise GC scan)",
-			got, want)
-	}
+	structlayout.AssertPointerFieldsFirst(t, reflect.TypeOf(revMatch{}))
 }

--- a/internal/rules/linkvalidity/rule.go
+++ b/internal/rules/linkvalidity/rule.go
@@ -219,10 +219,10 @@ func isInlineNode(n ast.Node) bool {
 // --- reversed-link scan (MD011) ---
 
 type revMatch struct {
-	col0     int // 0-based byte index of '(' within the line
-	matchEnd int // exclusive byte index just past ']' within the line
 	text     []byte
 	url      []byte
+	col0     int // 0-based byte index of '(' within the line
+	matchEnd int // exclusive byte index just past ']' within the line
 }
 
 // reversedNeedle is the two-byte sequence every reversedRe match must

--- a/internal/rules/noinlinehtml/alloc_test.go
+++ b/internal/rules/noinlinehtml/alloc_test.go
@@ -1,0 +1,34 @@
+package noinlinehtml
+
+import "testing"
+
+// allocBudgetExtractTagUppercase is the per-call ceiling for
+// extractTag on a mixed-case tag name. tagNameRe.FindSubmatch pays
+// one allocation for the match slice; the old
+// strings.ToLower(string(m[1])) paid two more whenever m[1] contained
+// an uppercase byte — the string(m[1]) copy, then strings.ToLower's
+// own buffer since it cannot return the input unchanged.
+// asciiLowerTag folds those two into one allocation, bringing the
+// total from 3 down to 2 — see
+// docs/development/high-performance-go.md "Allocations."
+const allocBudgetExtractTagUppercase = 2
+
+func TestExtractTagUppercaseAllocBudget(t *testing.T) {
+	if testing.Short() {
+		t.Skip("alloc gate skipped in -short mode")
+	}
+	if raceEnabled {
+		t.Skip("alloc gate skipped under -race")
+	}
+	raw := []byte("<DIV class=\"x\">")
+	_ = extractTag(raw) // warm up regex program cache
+	allocs := testing.AllocsPerRun(200, func() {
+		_ = extractTag(raw)
+	})
+	t.Logf("extractTag(uppercase) allocs/op = %.0f (budget = %d)", allocs, allocBudgetExtractTagUppercase)
+	if allocs > float64(allocBudgetExtractTagUppercase) {
+		t.Fatalf("extractTag(uppercase) allocs/op = %.0f, budget = %d: lowercase the "+
+			"matched bytes directly instead of string(m[1]) followed by strings.ToLower",
+			allocs, allocBudgetExtractTagUppercase)
+	}
+}

--- a/internal/rules/noinlinehtml/race_off_test.go
+++ b/internal/rules/noinlinehtml/race_off_test.go
@@ -1,0 +1,5 @@
+//go:build !race
+
+package noinlinehtml
+
+const raceEnabled = false

--- a/internal/rules/noinlinehtml/race_on_test.go
+++ b/internal/rules/noinlinehtml/race_on_test.go
@@ -1,0 +1,5 @@
+//go:build race
+
+package noinlinehtml
+
+const raceEnabled = true

--- a/internal/rules/noinlinehtml/rule.go
+++ b/internal/rules/noinlinehtml/rule.go
@@ -284,7 +284,30 @@ func extractTag(raw []byte) string {
 	if m == nil {
 		return ""
 	}
-	return strings.ToLower(string(m[1]))
+	return asciiLowerTag(m[1])
+}
+
+// asciiLowerTag returns the lowercased tag name for b in one
+// allocation. tagNameRe only matches [a-zA-Z][a-zA-Z0-9-]*, so b is
+// always ASCII: strings.ToLower(string(b)) allocates the string(b)
+// copy and then, for any uppercase input, a second buffer inside
+// strings.ToLower — see docs/development/high-performance-go.md's
+// allocation guidance on avoiding a redundant intermediate copy.
+func asciiLowerTag(b []byte) string {
+	for _, c := range b {
+		if 'A' <= c && c <= 'Z' {
+			var sb strings.Builder
+			sb.Grow(len(b))
+			for _, c := range b {
+				if 'A' <= c && c <= 'Z' {
+					c += 'a' - 'A'
+				}
+				sb.WriteByte(c)
+			}
+			return sb.String()
+		}
+	}
+	return string(b)
 }
 
 func isClosingTag(raw []byte) bool {

--- a/internal/rules/samefileanchor/layout_test.go
+++ b/internal/rules/samefileanchor/layout_test.go
@@ -1,23 +1,21 @@
 package samefileanchor
 
 import (
+	"reflect"
 	"testing"
-	"unsafe"
+
+	"github.com/jeduden/mdsmith/internal/structlayout"
 )
 
-// TestAnchorCheckerFieldOrder asserts that built (a bool, no pointers)
-// is the last field in anchorChecker, after the pointer-containing r,
-// f, slugs, and diags fields. Go's GC ptrdata for a struct spans from
-// offset 0 through the end of the last pointer-containing field, so a
-// scalar declared before diags (the last pointer field) costs GC scan
-// bytes for nothing. See docs/development/high-performance-go.md
-// "Struct layout". The test fails (red) until built is moved after
-// diags.
+// TestAnchorCheckerFieldOrder guards the GC ptrdata region of
+// anchorChecker: built (a bool, no pointers) must come after the
+// pointer-containing r, f, slugs, and diags fields. Go's GC ptrdata
+// for a struct spans from offset 0 through the end of the last
+// pointer-containing field, so a scalar declared before diags (the
+// last pointer field) costs GC scan bytes for nothing — a saving of
+// one word on a 64-bit platform. See
+// docs/development/high-performance-go.md "Struct layout". The test
+// fails (red) until built is moved after diags.
 func TestAnchorCheckerFieldOrder(t *testing.T) {
-	got := unsafe.Offsetof(anchorChecker{}.built)
-	const want = uintptr(48) // after r, f, slugs (8 bytes each) and diags (24 bytes)
-	if got != want {
-		t.Errorf("unsafe.Offsetof(anchorChecker.built) = %d; want %d (move built after diags to minimise GC scan)",
-			got, want)
-	}
+	structlayout.AssertPointerFieldsFirst(t, reflect.TypeOf(anchorChecker{}))
 }

--- a/internal/rules/samefileanchor/layout_test.go
+++ b/internal/rules/samefileanchor/layout_test.go
@@ -1,0 +1,23 @@
+package samefileanchor
+
+import (
+	"testing"
+	"unsafe"
+)
+
+// TestAnchorCheckerFieldOrder asserts that built (a bool, no pointers)
+// is the last field in anchorChecker, after the pointer-containing r,
+// f, slugs, and diags fields. Go's GC ptrdata for a struct spans from
+// offset 0 through the end of the last pointer-containing field, so a
+// scalar declared before diags (the last pointer field) costs GC scan
+// bytes for nothing. See docs/development/high-performance-go.md
+// "Struct layout". The test fails (red) until built is moved after
+// diags.
+func TestAnchorCheckerFieldOrder(t *testing.T) {
+	got := unsafe.Offsetof(anchorChecker{}.built)
+	const want = uintptr(48) // after r, f, slugs (8 bytes each) and diags (24 bytes)
+	if got != want {
+		t.Errorf("unsafe.Offsetof(anchorChecker.built) = %d; want %d (move built after diags to minimise GC scan)",
+			got, want)
+	}
+}

--- a/internal/rules/samefileanchor/rule.go
+++ b/internal/rules/samefileanchor/rule.go
@@ -72,8 +72,8 @@ type anchorChecker struct {
 	r     *Rule
 	f     *lint.File
 	slugs map[string]struct{}
-	built bool
 	diags []lint.Diagnostic
+	built bool
 }
 
 // visit records a diagnostic when n is a same-file fragment link whose

--- a/internal/rules/tableformat/checkcolumncount_alloc_test.go
+++ b/internal/rules/tableformat/checkcolumncount_alloc_test.go
@@ -40,3 +40,49 @@ func TestCheckColumnCountCompliant_NoAlloc(t *testing.T) {
 			"lazily via append instead of an eager make() that gets discarded", allocs)
 	}
 }
+
+// allocBudgetCheckColumnCountManyMismatches is the per-call ceiling
+// for checkColumnCount on a table with 6 column-count mismatches: 1
+// alloc for the presized diags slice plus 1 alloc per
+// fmt.Sprintf-built diagnostic message. A bare `var diags
+// []lint.Diagnostic` growing via unpresized append instead pays
+// growslice's doubling reallocations (measured 4 extra, for 10
+// total) on top of that — see
+// docs/development/high-performance-go.md "Pre-size slices."
+const allocBudgetCheckColumnCountManyMismatches = 7
+
+// checkColumnCountManyMismatchesFixture has a two-cell header and six
+// one-cell body rows, so every body row mismatches the header's cell
+// count and checkColumnCount must grow diags past the point a small
+// unpresized append would need to reallocate.
+const checkColumnCountManyMismatchesFixture = "| a | b |\n|---|---|\n" +
+	"| 1 |\n| 1 |\n| 1 |\n| 1 |\n| 1 |\n| 1 |\n"
+
+func TestCheckColumnCountManyMismatches_PresizedAllocBudget(t *testing.T) {
+	f, err := lint.NewFile("t.md", []byte(checkColumnCountManyMismatchesFixture))
+	require.NoError(t, err)
+	tables := findStructureTables(f.Lines, structureSkipFunc(f))
+	require.Len(t, tables, 1)
+	tbl := tables[0]
+
+	got := checkColumnCount(f, tbl, "MDS025", "table-format")
+	require.Lenf(t, got, 6, "fixture must produce one diagnostic per mismatched body row")
+
+	if testing.Short() {
+		t.Skip("alloc gate skipped in -short mode")
+	}
+	if raceEnabled {
+		t.Skip("alloc gate skipped under -race")
+	}
+	allocs := testing.AllocsPerRun(200, func() {
+		_ = checkColumnCount(f, tbl, "MDS025", "table-format")
+	})
+	t.Logf("checkColumnCount(6 mismatches) allocs/op = %.0f (budget = %d)",
+		allocs, allocBudgetCheckColumnCountManyMismatches)
+	if allocs > float64(allocBudgetCheckColumnCountManyMismatches) {
+		t.Fatalf("checkColumnCount(6 mismatches) allocs/op = %.0f, budget = %d: "+
+			"diags must be presized with make([]lint.Diagnostic, 0, len(t.rows)-1) "+
+			"on the first mismatch instead of growing via bare append",
+			allocs, allocBudgetCheckColumnCountManyMismatches)
+	}
+}

--- a/internal/rules/tableformat/checkcolumncount_alloc_test.go
+++ b/internal/rules/tableformat/checkcolumncount_alloc_test.go
@@ -1,0 +1,42 @@
+package tableformat
+
+import (
+	"testing"
+
+	"github.com/jeduden/mdsmith/internal/lint"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCheckColumnCountCompliant_NoAlloc pins that checkColumnCount
+// returns nil, with zero allocations, when every row's cell count
+// matches the header. The old make([]lint.Diagnostic, 0,
+// len(t.rows)-1) allocated a slice on every call and then discarded
+// it via `if len(diags) == 0 { return nil }` on this common
+// compliant-table path — see docs/development/high-performance-go.md's
+// "Return nil, not []T{}" pattern.
+func TestCheckColumnCountCompliant_NoAlloc(t *testing.T) {
+	f, err := lint.NewFile("t.md", []byte("| a | b |\n|---|---|\n| 1 | 2 |\n"))
+	require.NoError(t, err)
+	tables := findStructureTables(f.Lines, structureSkipFunc(f))
+	require.Len(t, tables, 1)
+	tbl := tables[0]
+
+	if got := checkColumnCount(f, tbl, "MDS025", "table-format"); got != nil {
+		t.Fatalf("checkColumnCount on a compliant table = %#v, want nil", got)
+	}
+
+	if testing.Short() {
+		t.Skip("alloc gate skipped in -short mode")
+	}
+	if raceEnabled {
+		t.Skip("alloc gate skipped under -race")
+	}
+	allocs := testing.AllocsPerRun(200, func() {
+		_ = checkColumnCount(f, tbl, "MDS025", "table-format")
+	})
+	t.Logf("checkColumnCount(compliant) allocs/op = %.0f", allocs)
+	if allocs > 0 {
+		t.Fatalf("checkColumnCount(compliant) allocs/op = %.0f, want 0: allocate diags "+
+			"lazily via append instead of an eager make() that gets discarded", allocs)
+	}
+}

--- a/internal/rules/tableformat/structure.go
+++ b/internal/rules/tableformat/structure.go
@@ -211,9 +211,9 @@ func checkPipeStyle(f *lint.File, t tableBlock, style, ruleID, ruleName string) 
 
 func checkColumnCount(f *lint.File, t tableBlock, ruleID, ruleName string) []lint.Diagnostic {
 	want := t.rows[0].cells
-	//nolint:prealloc // most tables are column-count compliant; an eager
-	// make() here would allocate a slice only to discard it on that
-	// common path, so diags starts nil and grows lazily instead.
+	// Most tables are column-count compliant; an eager make() here
+	// would allocate a slice only to discard it on that common path,
+	// so diags starts nil and grows lazily instead.
 	var diags []lint.Diagnostic
 	for _, row := range t.rows[1:] {
 		if row.cells == want {

--- a/internal/rules/tableformat/structure.go
+++ b/internal/rules/tableformat/structure.go
@@ -211,16 +211,16 @@ func checkPipeStyle(f *lint.File, t tableBlock, style, ruleID, ruleName string) 
 
 func checkColumnCount(f *lint.File, t tableBlock, ruleID, ruleName string) []lint.Diagnostic {
 	want := t.rows[0].cells
-	diags := make([]lint.Diagnostic, 0, len(t.rows)-1)
+	//nolint:prealloc // most tables are column-count compliant; an eager
+	// make() here would allocate a slice only to discard it on that
+	// common path, so diags starts nil and grows lazily instead.
+	var diags []lint.Diagnostic
 	for _, row := range t.rows[1:] {
 		if row.cells == want {
 			continue
 		}
 		diags = append(diags, structureDiag(f, row.lineNum, 1, ruleID, ruleName,
 			fmt.Sprintf("table column count; expected %d, got %d", want, row.cells)))
-	}
-	if len(diags) == 0 {
-		return nil
 	}
 	return diags
 }

--- a/internal/rules/tableformat/structure.go
+++ b/internal/rules/tableformat/structure.go
@@ -212,12 +212,19 @@ func checkPipeStyle(f *lint.File, t tableBlock, style, ruleID, ruleName string) 
 func checkColumnCount(f *lint.File, t tableBlock, ruleID, ruleName string) []lint.Diagnostic {
 	want := t.rows[0].cells
 	// Most tables are column-count compliant; an eager make() here
-	// would allocate a slice only to discard it on that common path,
-	// so diags starts nil and grows lazily instead.
+	// would allocate a slice only to discard it on that common path.
+	// diags starts nil and is presized to its exact upper bound
+	// (len(t.rows)-1) lazily, on the first mismatch, so a compliant
+	// table still costs nothing while a non-compliant one avoids the
+	// repeated-append regrowth a bare nil-append would pay — mirrors
+	// reversedInLine's lazy presize in internal/rules/linkvalidity.
 	var diags []lint.Diagnostic
 	for _, row := range t.rows[1:] {
 		if row.cells == want {
 			continue
+		}
+		if diags == nil {
+			diags = make([]lint.Diagnostic, 0, len(t.rows)-1)
 		}
 		diags = append(diags, structureDiag(f, row.lineNum, 1, ruleID, ruleName,
 			fmt.Sprintf("table column count; expected %d, got %d", want, row.cells)))

--- a/internal/rules/uniquefrontmatter/layout_test.go
+++ b/internal/rules/uniquefrontmatter/layout_test.go
@@ -1,24 +1,23 @@
 package uniquefrontmatter
 
 import (
+	"reflect"
 	"testing"
-	"unsafe"
+
+	"github.com/jeduden/mdsmith/internal/structlayout"
 )
 
-// TestPathEntryFieldOrder asserts that line (an int, no pointers) is
-// the last field in pathEntry, after the pointer-containing value and
-// firstPath strings. Go's GC ptrdata for a struct spans from offset 0
-// through the end of the last pointer-containing field, so a scalar
-// declared between two string fields costs GC scan bytes for nothing.
-// pathEntry is stored once per violation in scopeIndex.byPath, an
-// index built across the whole workspace, so the saving scales with
-// corpus size. See docs/development/high-performance-go.md "Struct
-// layout". The test fails (red) until line is moved after firstPath.
+// TestPathEntryFieldOrder guards the GC ptrdata region of pathEntry:
+// line (an int, no pointers) must come after the pointer-containing
+// value and firstPath strings. Go's GC ptrdata for a struct spans
+// from offset 0 through the end of the last pointer-containing
+// field, so a scalar sandwiched between two string fields costs GC
+// scan bytes for nothing — a saving of one word on a 64-bit
+// platform. pathEntry is stored once per violation in
+// scopeIndex.byPath, an index built across the whole workspace, so
+// the saving scales with corpus size. See
+// docs/development/high-performance-go.md "Struct layout". The test
+// fails (red) until line is moved after firstPath.
 func TestPathEntryFieldOrder(t *testing.T) {
-	got := unsafe.Offsetof(pathEntry{}.line)
-	const want = uintptr(32) // after value and firstPath (16 bytes each)
-	if got != want {
-		t.Errorf("unsafe.Offsetof(pathEntry.line) = %d; want %d (move line after firstPath to minimise GC scan)",
-			got, want)
-	}
+	structlayout.AssertPointerFieldsFirst(t, reflect.TypeOf(pathEntry{}))
 }

--- a/internal/rules/uniquefrontmatter/layout_test.go
+++ b/internal/rules/uniquefrontmatter/layout_test.go
@@ -1,0 +1,24 @@
+package uniquefrontmatter
+
+import (
+	"testing"
+	"unsafe"
+)
+
+// TestPathEntryFieldOrder asserts that line (an int, no pointers) is
+// the last field in pathEntry, after the pointer-containing value and
+// firstPath strings. Go's GC ptrdata for a struct spans from offset 0
+// through the end of the last pointer-containing field, so a scalar
+// declared between two string fields costs GC scan bytes for nothing.
+// pathEntry is stored once per violation in scopeIndex.byPath, an
+// index built across the whole workspace, so the saving scales with
+// corpus size. See docs/development/high-performance-go.md "Struct
+// layout". The test fails (red) until line is moved after firstPath.
+func TestPathEntryFieldOrder(t *testing.T) {
+	got := unsafe.Offsetof(pathEntry{}.line)
+	const want = uintptr(32) // after value and firstPath (16 bytes each)
+	if got != want {
+		t.Errorf("unsafe.Offsetof(pathEntry.line) = %d; want %d (move line after firstPath to minimise GC scan)",
+			got, want)
+	}
+}

--- a/internal/rules/uniquefrontmatter/rule.go
+++ b/internal/rules/uniquefrontmatter/rule.go
@@ -56,8 +56,8 @@ func (r *Rule) Category() string { return "structural" }
 // file line of the field, and the first path holding the value.
 type pathEntry struct {
 	value     string
-	line      int
 	firstPath string
+	line      int
 }
 
 // scopeIndex maps each in-scope file whose value repeats an earlier


### PR DESCRIPTION
## Summary

Scheduled performance audit against
[docs/development/high-performance-go.md](docs/development/high-performance-go.md).
Three background agents scanned `internal/` and `pkg/` for allocation-budget
violations, "Patterns to avoid" anti-patterns, and struct-layout/data-structure
issues. The codebase turned out to already be heavily scrubbed for these
patterns (most candidates the agents flagged were already-correct, documented
optimizations); the five real, safely-fixable violations below were selected
and fixed with red/green TDD, each in its own commit:

1. **`internal/rules/linkvalidity` (MDS062, default-on)** — `revMatch`
   declared its two ints (`col0`, `matchEnd`) before its two byte slices
   (`text`, `url`). Go's GC ptrdata spans from offset 0 through the last
   pointer-containing field, so with scalars first, ptrdata still had to
   cover both slices anyway. Grouping the slices first and the scalars last
   shrinks ptrdata from 48 to 32 bytes — the largest win in this pass.
2. **`internal/rules/uniquefrontmatter` (MDS069, default-on)** — `pathEntry`
   sandwiched an `int` between two strings. `pathEntry` is stored once per
   violation in the run-wide `scopeIndex.byPath` index, so the 8-byte ptrdata
   saving scales with corpus size.
3. **`internal/rules/samefileanchor` (MDS070, default-on)** — `anchorChecker`
   declared a `bool` before its trailing `[]lint.Diagnostic`. Moved after,
   saving 8 bytes of ptrdata per file that contains a `#`.
4. **`internal/rules/noinlinehtml` (MDS041)** — `extractTag` built the tag
   name via `strings.ToLower(string(m[1]))`: one allocation for the
   `string(m[1])` copy, plus a second whenever the tag had an uppercase byte
   (since `strings.ToLower` can't return the input unchanged). `tagNameRe`
   only ever matches ASCII, so the new `asciiLowerTag` lowercases the matched
   bytes directly into one `strings.Builder` allocation — a mixed-case tag
   drops from 3 allocs/call to 2.
5. **`internal/rules/tableformat` (MDS025, default-on, per-file)** —
   `checkColumnCount` unconditionally called
   `make([]lint.Diagnostic, 0, len(t.rows)-1)`, then discarded it and
   returned `nil` on the common column-count-compliant path. Now starts
   `diags` as `nil` and grows it lazily via `append`, matching the project's
   own "return nil, not `[]T{}`" convention — one fewer allocation per
   compliant table, on every workspace file.

Each fix carries a dedicated test (a `structlayout.AssertPointerFieldsFirst`
layout assertion matching the pattern in `tablereadability`, `propernames`,
`astutil`, or a `testing.AllocsPerRun` allocation budget) that was verified
red against the pre-fix code (via `git stash`, or a direct diff against the
pre-PR commit) before the fix made it green.

MDS025's full fix (merging the structure pass with `tablefmt`'s own
alignment scan) is a larger, already-documented "single-table-walk refactor"
(see the comment in `internal/rules/tableformat/alloc_test.go`) that this PR
does not attempt — it's out of scope for a set of small, safely verifiable
fixes.

**Code review**: three xhigh-severity `/code-review` passes, as required.
Round 1: no findings. Round 2: three findings — two were valid (the three
new layout tests used hardcoded, pointer-size-dependent `unsafe.Offsetof`
constants instead of the repo's existing portable
`structlayout.AssertPointerFieldsFirst` helper; a `//nolint:prealloc` pragma
on `checkColumnCount` suppressed nothing, confirmed empirically) and were
fixed in a follow-up commit; the third (a claimed ptrdata-savings miscalculation
in a comment) was independently verified against Go's actual `PtrDataSize`
algorithm and found to be incorrect — the original 48→32 byte figure was
correct, so no change was made there. Round 3 (after the fix commit):
no findings.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite green)
- [x] `go tool -modfile=tools/go.mod golangci-lint run` (0 issues, repo-wide)
- [x] `go test ./internal/integration/... -run TestPerRuleAllocBudget` (per-rule alloc gate green)
- [x] `mdsmith check .` (584 files, 0 failures)
- [x] Each fix's test verified red (via `git stash`/pre-fix diff) before green
- [x] Three xhigh-severity `/code-review` passes, findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RcWK6hTskkM6F6qVTpnWJb