### PR TITLE
Replace coined homepage/README copy with plain words

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Quality][grc-badge]][grc-link]
 [![Coverage][cov-badge]][cov-link]
 
-Mark*down*, smithed.
+Neat, consistent *Markdown*.
 
 <?include
 file: docs/brand/messaging.md

--- a/docs/brand/messaging.md
+++ b/docs/brand/messaging.md
@@ -36,7 +36,7 @@ statement.
 
 ## Headline
 
-Mark*down*, smithed.
+Neat, consistent *Markdown*.
 
 ## Eyebrow
 

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -3,9 +3,9 @@ title: "mdsmith"
 summary: "Write content; mdsmith keeps your Markdown neat and consistent — fast enough to stay out of your way. Auto-fix on save, instant navigation, cross-file integrity, and generated sections that keep a single source of truth in sync across files and pipelines."
 hero:
   eyebrow: "Markdown as a single source of truth"
-  headline_pre: "Mark"
-  headline_em: "down"
-  headline_post: ", smithed."
+  headline_pre: "Neat, consistent "
+  headline_em: "Markdown"
+  headline_post: "."
   lead: "mdsmith is a Markdown linter and formatter that keeps your writing neat and consistent — fast enough to stay out of your way."
 positioning:
   surfaces:

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -34,8 +34,8 @@
   <section class="section">
     <div class="container">
       <div class="section-eyebrow">Why mdsmith</div>
-      <h2 class="section-title">Forged <em>whole.</em></h2>
-      <p class="section-lead">Where other linters stop at per-file style, mdsmith forges the whole tree: it checks readability, ties files together with links, includes, and schemas, keeps generated sections in sync, and gates the result in CI — all from one engine that runs the same in your editor, your agent, and your pipeline.</p>
+      <h2 class="section-title">Checks the <em>whole</em> tree.</h2>
+      <p class="section-lead">Where other linters stop at per-file style, mdsmith checks the whole tree: it grades readability, ties files together with links, includes, and schemas, keeps generated sections in sync, and gates the result in CI — all from one engine that runs the same in your editor, your agent, and your pipeline.</p>
       {{ partial "feature-grid.html" . }}
     </div>
   </section>


### PR DESCRIPTION
Implements **Tier 1** of plan [`2608301343`](https://github.com/jeduden/mdsmith/blob/main/plan/2608301343_reduce-homepage-clutter.md): swap the forge-metaphor marketing copy for words the target audience knows on first read. This is the copy the previous PR only *planned* — here it actually changes.

## Changes

| Where | Before | After |
|---|---|---|
| Hero headline | `Mark*down*, smithed.` | `Neat, consistent *Markdown*.` |
| "Why mdsmith" section title | `Forged *whole.*` | `Checks the *whole* tree.` |
| that section's lead | "mdsmith **forges** the whole tree: it **checks** readability…" | "mdsmith **checks** the whole tree: it **grades** readability…" |

Four files:

- `docs/brand/messaging.md` — the headline source of truth.
- `README.md` — the literal headline line (not a `sync-messaging` surface, edited directly).
- `website/content/_index.md` — hero `headline_pre` / `_em` / `_post`, updated by `mdsmith-release sync-messaging`.
- `website/layouts/index.html` — the homepage section title and lead (hardcoded template copy, not messaging-managed).

## Validation

- `mdsmith-release sync-messaging --check` → every tracked surface matches the source.
- `mdsmith check .` → `checked=585 failures=0`.
- `go test ./internal/release/... ./internal/extract/... ./cmd/mdsmith-release/... ./cmd/mdsmith/ -run Messaging|Extract` → pass. The remaining `smithed` strings are self-contained `extract` **test fixtures** and two docs examples of the `extract` command — sample data, not marketing copy — left as-is per the plan.

## Notes

- Copy only. **No changes to `.mdsmith.yml`.**
- Once this merges to `main`, `pages.yml` auto-deploys `mdsmith.dev` (the diff touches `docs/**` + `website/**`).
- Headline wording is the one brand call — say the word if you'd prefer `Markdown, kept *tidy*.` or `Clean, consistent *Markdown*.` and I'll swap the single line.
- Tier 2 (drop the `MDS###` chips from the homepage cards) and Tier 3 (pillar numbers, icon-tile hues, hero badges) are not in this PR — happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fz8YieM4TTjBTkpjfKx5Ek

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fz8YieM4TTjBTkpjfKx5Ek)_